### PR TITLE
Feat: Add support for HTTP(S) proxy set via environmental variables

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -18,6 +18,8 @@ const project = new JsiiProject({
     'yaml@2.0.0-5',
     'follow-redirects',
     'fast-json-patch',
+    'http-proxy-agent',
+    'https-proxy-agent',
   ],
   devDeps: [
     'constructs',

--- a/src/_loadurl.js
+++ b/src/_loadurl.js
@@ -8,6 +8,8 @@
 const { http, https } = require('follow-redirects');
 const { parse } = require('url');
 const fs = require('fs');
+const HttpProxyAgent = require('http-proxy-agent');
+const HttpsProxyAgent = require('https-proxy-agent');
 
 const url = process.argv[2];
 if (!url) {
@@ -27,7 +29,12 @@ try {
   }
   
   const client = getHttpClient(purl.protocol);
-  const get = client.get(url, response => {
+  const proxyUrl = purl.protocol == 'https:' ? process.env.https_proxy : process.env.http_proxy
+  if (proxyUrl && purl.hostname && useProxy(purl.hostname)) {
+    purl.agent = purl.protocol == 'https:' ? new HttpsProxyAgent(proxyUrl) : new HttpProxyAgent(proxyUrl)
+  }
+
+  const get = client.get(purl, response => {
     if (response.statusCode !== 200) {
       throw new Error(`${response.statusCode} response from http get: ${response.statusMessage}`);
     }
@@ -47,4 +54,19 @@ function getHttpClient(protocol) {
     default:
       throw new Error(`unsupported protocol "${protocol}" in url: ${url}`);
   }
+}
+
+function useProxy(hostname) {
+  const hosts = (process.env.no_proxy || '').split(',')
+  for (i in hosts) {
+    host = hosts[i]
+    if (host[0] == '.') {
+      if (hostname.endsWith(host)) {
+        return false
+      }
+    } else if (host == hostname) {
+      return false
+    }
+  }
+  return true
 }


### PR DESCRIPTION
Fixes #11
Use environmental variables `http_proxy`, `https_proxy` and `no_proxy` to determine behaviour.

Original pull request: https://github.com/cdk8s-team/cdk8s/pull/572

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license