### PR TITLE
feat: Allow configuration of how YAML output is divided into files

### DIFF
--- a/API.md
+++ b/API.md
@@ -49,6 +49,7 @@ Name|Description
 Name|Description
 ----|-----------
 [SizeRoundingBehavior](#cdk8s-sizeroundingbehavior)|Rounding behaviour when converting between units of `Size`.
+[YamlOutputType](#cdk8s-yamloutputtype)|The method to divide YAML output into files.
 
 
 
@@ -274,6 +275,7 @@ new App(props?: AppProps)
 
 * **props** (<code>[AppProps](#cdk8s-appprops)</code>)  configuration options.
   * **outdir** (<code>string</code>)  The directory to output Kubernetes manifests. __*Default*__: CDK8S_OUTDIR if defined, otherwise "dist"
+  * **yamlOutputType** (<code>[YamlOutputType](#cdk8s-yamloutputtype)</code>)  How to divide the YAML output into files. __*Default*__: YamlOutputType.FILE_PER_CHART
 
 
 
@@ -283,6 +285,7 @@ new App(props?: AppProps)
 Name | Type | Description 
 -----|------|-------------
 **outdir** | <code>string</code> | The output directory into which manifests will be synthesized.
+**yamlOutputType** | <code>[YamlOutputType](#cdk8s-yamloutputtype)</code> | How to divide the YAML output into files.
 
 ### Methods
 
@@ -1186,14 +1189,17 @@ Testing utilities for cdk8s applications.
 ### Methods
 
 
-#### *static* app() <a id="cdk8s-testing-app"></a>
+#### *static* app(props?) <a id="cdk8s-testing-app"></a>
 
 Returns an app for testing with the following properties: - Output directory is a temp dir.
 
 ```ts
-static app(): App
+static app(props?: AppProps): App
 ```
 
+* **props** (<code>[AppProps](#cdk8s-appprops)</code>)  *No description*
+  * **outdir** (<code>string</code>)  The directory to output Kubernetes manifests. __*Default*__: CDK8S_OUTDIR if defined, otherwise "dist"
+  * **yamlOutputType** (<code>[YamlOutputType](#cdk8s-yamloutputtype)</code>)  How to divide the YAML output into files. __*Default*__: YamlOutputType.FILE_PER_CHART
 
 __Returns__:
 * <code>[App](#cdk8s-app)</code>
@@ -1331,6 +1337,7 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **outdir**? | <code>string</code> | The directory to output Kubernetes manifests.<br/>__*Default*__: CDK8S_OUTDIR if defined, otherwise "dist"
+**yamlOutputType**? | <code>[YamlOutputType](#cdk8s-yamloutputtype)</code> | How to divide the YAML output into files.<br/>__*Default*__: YamlOutputType.FILE_PER_CHART
 
 
 
@@ -1464,5 +1471,16 @@ Name | Description
 **FAIL** |Fail the conversion if the result is not an integer.
 **FLOOR** |If the result is not an integer, round it to the closest integer less than the result.
 **NONE** |Don't round.
+
+
+## enum YamlOutputType  <a id="cdk8s-yamloutputtype"></a>
+
+The method to divide YAML output into files.
+
+Name | Description
+-----|-----
+**FILE_PER_APP** |All resources are output into a single YAML file.
+**FILE_PER_CHART** |Resources are split into seperate files by chart.
+**FILE_PER_RESOURCE** |Each resource is output to its own file.
 
 

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { App } from './app';
+import { App, AppProps } from './app';
 import { Chart } from './chart';
 
 /**
@@ -12,9 +12,14 @@ export class Testing {
    * Returns an app for testing with the following properties:
    * - Output directory is a temp dir.
    */
-  public static app() {
-    const outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk8s.outdir.'));
-    return new App({ outdir });
+  public static app(props?: AppProps) {
+    let outdir: string;
+    if (props) {
+      outdir = props.outdir ?? fs.mkdtempSync(path.join(os.tmpdir(), 'cdk8s.outdir.'));
+    } else {
+      outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk8s.outdir.'));
+    }
+    return new App({ outdir, ...props });
   }
 
   /**

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { Node, Construct } from 'constructs';
-import { Testing, Chart, App, ApiObject } from '../src';
+import { Testing, Chart, App, ApiObject, YamlOutputType } from '../src';
 
 test('empty app emits no files', () => {
   // GIVEN
@@ -258,4 +258,127 @@ test('synth calls validate', () => {
 
   expect(construct.validateInvoked).toBeTruthy();
 
+});
+
+test('apps with varying yamlOutputTypes; two charts, no objects', () => {
+  const testSpecs = [
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_CHART },
+      result: ['chart1.k8s.yaml', 'chart2.k8s.yaml'],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_APP },
+      result: ['app.k8s.yaml'],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_RESOURCE },
+      result: [],
+    },
+  ];
+  for (const testSpec of testSpecs) {
+    // GIVEN
+    const app = Testing.app(testSpec.props);
+
+    // WHEN
+    new Chart(app, 'chart1');
+    new Chart(app, 'chart2');
+    app.synth();
+
+    // THEN
+    expect(fs.readdirSync(app.outdir)).toEqual(testSpec.result);
+  }
+});
+
+test('apps with varying yamlOutputTypes; charts indirectly dependant, multiple objects', () => {
+  const testSpecs = [
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_CHART },
+      result: [
+        '0000-chart3.k8s.yaml',
+        '0001-chart2.k8s.yaml',
+        '0002-chart1.k8s.yaml',
+      ],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_APP },
+      result: ['app.k8s.yaml'],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_RESOURCE },
+      result: [
+        'Kind1.chart1-obj1-c818e77f.k8s.yaml',
+        'Kind2.chart2-obj2-c8636f20.k8s.yaml',
+        'Kind3.chart3-obj3-c8abbfb5.k8s.yaml',
+      ],
+    },
+  ];
+
+  for (const testSpec of testSpecs) {
+    // GIVEN
+    const app = Testing.app(testSpec.props);
+
+    // WHEN
+    const chart1 = new Chart(app, 'chart1');
+    const chart2 = new Chart(app, 'chart2');
+    const chart3 = new Chart(app, 'chart3');
+
+    const obj1 = new ApiObject(chart1, 'obj1', { apiVersion: 'v1', kind: 'Kind1' });
+    const obj2 = new ApiObject(chart2, 'obj2', { apiVersion: 'v1', kind: 'Kind2' });
+    const obj3 = new ApiObject(chart3, 'obj3', { apiVersion: 'v1', kind: 'Kind3' });
+
+    Node.of(obj1).addDependency(obj2);
+    Node.of(obj2).addDependency(obj3);
+
+    app.synth();
+
+    // THEN
+    expect(fs.readdirSync(app.outdir)).toEqual(testSpec.result);
+  }
+});
+
+test('apps with varying yamlOutputTypes; chart dependencies via custom constructs', () => {
+
+  class CustomConstruct extends Construct {
+
+    public obj: ApiObject;
+
+    constructor(scope: Construct, id: string) {
+      super(scope, id);
+
+      this.obj = new ApiObject(this, `${id}obj`, { apiVersion: 'v1', kind: 'CustomConstruct' });
+    }
+  }
+
+  const testSpecs = [
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_CHART },
+      result: ['0000-chart2.k8s.yaml', '0001-chart1.k8s.yaml'],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_APP },
+      result: ['app.k8s.yaml'],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_RESOURCE },
+      result: [
+        'CustomConstruct.chart1-microservice-microserviceobj-c8e1164f.k8s.yaml',
+        'CustomConstruct.chart2-database-databaseobj-c8b5eba3.k8s.yaml',
+      ],
+    },
+  ];
+
+  for (const testSpec of testSpecs) {
+    const app = Testing.app(testSpec.props);
+    const chart1 = new Chart(app, 'chart1');
+    const chart2 = new Chart(app, 'chart2');
+
+    const microService = new CustomConstruct(chart1, 'MicroService');
+    const dataBase = new CustomConstruct(chart2, 'DataBase');
+
+    Node.of(microService).addDependency(dataBase);
+
+    app.synth();
+
+    expect(fs.readdirSync(app.outdir)).toEqual(testSpec.result);
+  }
 });


### PR DESCRIPTION
This is a re-submission of https://github.com/cdk8s-team/cdk8s/pull/528, as @iliapolo requested.

This adds an optional configuration value to AppProps, to allow the output from the App to be divided into files in multiple different ways:

- One YAML file for the entire App
- One YAML file per chart, which is the current behavior, and the new default
- One YAML file per K8S resource, with the file name formatted as `${Kind}.${Name}.k8s.yaml`

This should be backwards compatible, as the per chart behavior has not changed, but I'm open to suggestions on a better way of implementing this, it may not be as intuitive as I think it is.

Fixes #37 