### PR TITLE
fix: duplicated objects when charts are nested

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -112,6 +112,7 @@ export class App extends Construct {
 
 function validate(app: App) {
 
+  // Note this is a copy-paste of https://github.com/aws/constructs/blob/master/lib/construct.ts#L438.
   const errors = Node.of(app).validate();
   if (errors.length > 0) {
     const errorList = errors.map(e => `[${Node.of(e.source).path}] ${e.message}`).join('\n  ');

--- a/test/__snapshots__/app.test.ts.snap
+++ b/test/__snapshots__/app.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`app with nested charts will deduplicate api objects (with inheritance) 1`] = `
+exports[`app with nested charts will deduplicate api objects (using custom classes) 1`] = `
 "apiVersion: v1
 kind: Namespace
 metadata:
@@ -8,7 +8,7 @@ metadata:
 "
 `;
 
-exports[`app with nested charts will deduplicate api objects (with inheritance) 2`] = `
+exports[`app with nested charts will deduplicate api objects (using custom classes) 2`] = `
 "apiVersion: v1
 kind: Namespace
 metadata:
@@ -16,7 +16,7 @@ metadata:
 "
 `;
 
-exports[`app with nested charts will deduplicate api objects (with inheritance) 3`] = `
+exports[`app with nested charts will deduplicate api objects (using custom classes) 3`] = `
 "apiVersion: v1
 kind: Namespace
 metadata:

--- a/test/__snapshots__/app.test.ts.snap
+++ b/test/__snapshots__/app.test.ts.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`app with nested charts will deduplicate api objects (with inheritance) 1`] = `
+"apiVersion: v1
+kind: Namespace
+metadata:
+  name: parent-child1-namespace1-c871643e
+"
+`;
+
+exports[`app with nested charts will deduplicate api objects (with inheritance) 2`] = `
+"apiVersion: v1
+kind: Namespace
+metadata:
+  name: parent-child2-namespace2-c806260b
+"
+`;
+
+exports[`app with nested charts will deduplicate api objects (with inheritance) 3`] = `
+"apiVersion: v1
+kind: Namespace
+metadata:
+  name: parent-namespace3-c8bf842a
+"
+`;
+
 exports[`app with nested charts will deduplicate api objects 1`] = `
 "apiVersion: v1
 kind: CustomConstruct

--- a/test/__snapshots__/app.test.ts.snap
+++ b/test/__snapshots__/app.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`app with nested charts will deduplicate api objects 1`] = `
+"apiVersion: v1
+kind: CustomConstruct
+metadata:
+  name: chart1-chart2-child2-child2obj-c828dca6
+"
+`;
+
+exports[`app with nested charts will deduplicate api objects 2`] = `
+"apiVersion: v1
+kind: CustomConstruct
+metadata:
+  name: chart1-child1-child1obj-c868628e
+"
+`;

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -191,17 +191,9 @@ test('app with nested charts will deduplicate api objects', () => {
   expect(fs.readFileSync(path.join(app.outdir, '0000-chart1-chart2-c883b207.k8s.yaml'), 'utf8')).toMatchSnapshot();
   expect(fs.readFileSync(path.join(app.outdir, '0001-chart1.k8s.yaml'), 'utf8')).toMatchSnapshot();
 
-  // a parent chart rendered by itself will not include resources belonging to children charts
-  expect(Testing.synth(chart)).toMatchObject([
-    { apiVersion: 'v1', kind: 'CustomConstruct', metadata: { name: 'chart1-child1-child1obj-c868628e' } },
-  ]);
-  expect(Testing.synth(childChart)).toMatchObject([
-    { apiVersion: 'v1', kind: 'CustomConstruct', metadata: { name: 'chart1-chart2-child2-child2obj-c828dca6' } },
-  ]);
-
 });
 
-test('app with nested charts will deduplicate api objects (with inheritance)', () => {
+test('app with nested charts will deduplicate api objects (using custom classes)', () => {
 
   class ChildChart1 extends Chart {
     constructor(scope: Construct, name: string) {

--- a/test/chart.test.ts
+++ b/test/chart.test.ts
@@ -269,6 +269,23 @@ describe('toJson', () => {
 
   });
 
+  test('parent chart does not include objects of children charts', () => {
+
+    const app = Testing.app();
+    const chart = new Chart(app, 'chart1');
+    const childChart = new Chart(chart, 'chart2');
+    new CustomConstruct(chart, 'child1');
+    new CustomConstruct(childChart, 'child2');
+
+    expect(chart.toJson()).toMatchObject([
+      { apiVersion: 'v1', kind: 'CustomConstruct', metadata: { name: 'chart1-child1-child1obj-c868628e' } },
+    ]);
+    expect(childChart.toJson()).toMatchObject([
+      { apiVersion: 'v1', kind: 'CustomConstruct', metadata: { name: 'chart1-chart2-child2-child2obj-c828dca6' } },
+    ]);
+
+  });
+
 });
 
 function createImplictToken(value: any) {


### PR DESCRIPTION
Fixes #31

I think the expected behavior from users is that in most circumstances, you should be able to directly apply resources generated by `cdk8s synth` to your k8s cluster (e.g. via `kubectl apply -f dist/`). However, it's possible for nested charts to cause resources to be listed twice. This PR resolves this by de-duplicating resources so that each one is only rendered once during a given "synth" call.

This PR makes the assumption that nesting charts within each other is implicitly a feature (I don't believe there are any other ways to arrive at charts containing the same resource twice?). It's possible we could instead add some kind of validation to prevent charts from being nested to resolve this issue instead, but this would become problematic if users are defining constructs that include charts.

Questions:
- Should there be some way to synthesize a specific chart within an app from the CLI?
- Should there be an option for synthesis (e.g. a CLI flag) to override this and allow duplicate objects?