### PR TITLE
chore: deprecate node v10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 10.17.0
+          node-version: 12.13.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 10.17.0
+          node-version: 12.13.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 10.17.0
+          node-version: 12.13.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^10.17.0",
+      "version": "^12.13.0",
       "type": "build"
     },
     {
@@ -106,7 +106,7 @@
     },
     {
       "name": "yaml",
-      "version": "2.0.0-5",
+      "version": "2.0.0-7",
       "type": "bundled"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -15,7 +15,7 @@ const project = new JsiiProject({
   ],
 
   bundledDeps: [
-    'yaml@2.0.0-5',
+    'yaml@2.0.0-7',
     'follow-redirects',
     'fast-json-patch',
   ],
@@ -33,7 +33,7 @@ const project = new JsiiProject({
   ],
 
   defaultReleaseBranch: 'main',
-  minNodeVersion: '10.17.0',
+  minNodeVersion: '12.13.0',
 
   // jsii configuration
   publishToMaven: {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@types/follow-redirects": "^1.13.1",
     "@types/jest": "^26.0.24",
-    "@types/node": "^10.17.0",
+    "@types/node": "^12.13.0",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.30.0",
     "constructs": "^3.3.140",
@@ -68,7 +68,7 @@
   "dependencies": {
     "fast-json-patch": "^2.2.1",
     "follow-redirects": "^1.14.3",
-    "yaml": "2.0.0-5"
+    "yaml": "2.0.0-7"
   },
   "bundledDependencies": [
     "fast-json-patch",
@@ -82,7 +82,7 @@
     "kubernetes"
   ],
   "engines": {
-    "node": ">= 10.17.0"
+    "node": ">= 12.13.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/test/helm.test.ts
+++ b/test/helm.test.ts
@@ -103,7 +103,7 @@ test('helmFlags can be used to specify additional helm options', () => {
     stderr: Buffer.from(''),
     stdout: Buffer.from(''),
     pid: 123,
-    output: ['stdout', 'stderr'],
+    output: [Buffer.from('stdout', 'utf8'), Buffer.from('stderr', 'utf8')],
     signal: null,
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -832,10 +832,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.10.tgz#7aa732cc47341c12a16b7d562f519c2383b6d4fc"
   integrity sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==
 
-"@types/node@^10.17.0":
-  version "10.17.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
-  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
+"@types/node@^12.13.0":
+  version "12.20.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.24.tgz#c37ac69cb2948afb4cef95f424fa0037971a9a5c"
+  integrity sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -6665,10 +6665,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@2.0.0-5:
-  version "2.0.0-5"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-5.tgz#00906046dc119427b2b4f7cf9041d34682d1480b"
-  integrity sha512-qH5L5eqW8cyv/N1U6rkK/O0M7kOK3BSo48d05Ptm03ITNsVFwg6TQ47wR72Db/ULWH5RfNJv+CqnG17Pyn8eqQ==
+yaml@2.0.0-7:
+  version "2.0.0-7"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-7.tgz#9799d9d85dfc8f01e4cc425e18e09215364beef1"
+  integrity sha512-RbI2Tm3hl9AoHY4wWyWvGvJfFIbHOzuzaxum6ez1A0vve+uXgNor03Wys4t+2sgjJSVSe+B2xerd1/dnvqHlOA==
 
 yaml@^1.10.2:
   version "1.10.2"


### PR DESCRIPTION
Node v10 is now deprecated and is no longer being maintained. This should unblock the currently failing upgrade workflow. (https://github.com/cdk8s-team/cdk8s-core/runs/3528803052)