### PR TITLE
chore: merge `Yaml.formatObjects` and `Yaml.stringify`

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -2276,7 +2276,7 @@ YAML utilities.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `formatObjects` <a name="org.cdk8s.Yaml.formatObjects"></a>
+##### ~~`formatObjects`~~ <a name="org.cdk8s.Yaml.formatObjects"></a>
 
 ```java
 import org.cdk8s.Yaml;
@@ -2287,8 +2287,6 @@ Yaml.formatObjects(java.util.List<java.lang.Object> docs)
 ###### `docs`<sup>Required</sup> <a name="org.cdk8s.Yaml.parameter.docs"></a>
 
 - *Type:* java.util.List<`java.lang.Object`>
-
-The set of objects.
 
 ---
 
@@ -2337,14 +2335,14 @@ The set of objects.
 ```java
 import org.cdk8s.Yaml;
 
-Yaml.stringify(java.lang.Object doc)
+Yaml.stringify(java.lang.Object docs)
 ```
 
-###### `doc`<sup>Required</sup> <a name="org.cdk8s.Yaml.parameter.doc"></a>
+###### `docs`<sup>Required</sup> <a name="org.cdk8s.Yaml.parameter.docs"></a>
 
 - *Type:* `java.lang.Object`
 
-An object.
+A set of objects to convert to YAML.
 
 ---
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -2539,7 +2539,7 @@ YAML utilities.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `format_objects` <a name="cdk8s.Yaml.format_objects"></a>
+##### ~~`format_objects`~~ <a name="cdk8s.Yaml.format_objects"></a>
 
 ```python
 import cdk8s
@@ -2552,8 +2552,6 @@ cdk8s.Yaml.format_objects(
 ###### `docs`<sup>Required</sup> <a name="cdk8s.Yaml.parameter.docs"></a>
 
 - *Type:* typing.List[`typing.Any`]
-
-The set of objects.
 
 ---
 
@@ -2608,15 +2606,15 @@ The set of objects.
 import cdk8s
 
 cdk8s.Yaml.stringify(
-  doc: typing.Any
+  docs: typing.Any
 )
 ```
 
-###### `doc`<sup>Required</sup> <a name="cdk8s.Yaml.parameter.doc"></a>
+###### `docs`<sup>Required</sup> <a name="cdk8s.Yaml.parameter.docs"></a>
 
 - *Type:* `typing.Any`
 
-An object.
+A set of objects to convert to YAML.
 
 ---
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2001,7 +2001,7 @@ YAML utilities.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `formatObjects` <a name="cdk8s.Yaml.formatObjects"></a>
+##### ~~`formatObjects`~~ <a name="cdk8s.Yaml.formatObjects"></a>
 
 ```typescript
 import { Yaml } from 'cdk8s'
@@ -2012,8 +2012,6 @@ Yaml.formatObjects(docs: any[])
 ###### `docs`<sup>Required</sup> <a name="cdk8s.Yaml.parameter.docs"></a>
 
 - *Type:* `any`[]
-
-The set of objects.
 
 ---
 
@@ -2062,14 +2060,14 @@ The set of objects.
 ```typescript
 import { Yaml } from 'cdk8s'
 
-Yaml.stringify(doc: any)
+Yaml.stringify(docs: any)
 ```
 
-###### `doc`<sup>Required</sup> <a name="cdk8s.Yaml.parameter.doc"></a>
+###### `docs`<sup>Required</sup> <a name="cdk8s.Yaml.parameter.docs"></a>
 
 - *Type:* `any`
 
-An object.
+A set of objects to convert to YAML.
 
 ---
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -176,19 +176,16 @@ export class App extends Construct {
   public synthYaml(): any {
     validate(this);
 
-    var yamls: string[] = [];
     const charts = this.charts;
+    const docs: any[] = [];
 
     for (const chart of charts) {
       const apiObjects = chartToKube(chart);
-
-      yamls.push(Yaml.formatObjects(apiObjects.map((apiObject) => apiObject.toJson())));
+      docs.push(...apiObjects.map(apiObject => apiObject.toJson()));
     }
 
-    yamls = yamls.filter((a) => a); // removes empty elements in array
-    return yamls.join('---\n'); // still need to do this since the yaml formatObjects does not add a --- at the end of every object
+    return Yaml.stringify(...docs);
   }
-
 }
 
 function validate(app: App) {

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -15,22 +15,11 @@ YAML.defaultOptions.version = '1.1';
  * YAML utilities.
  */
 export class Yaml {
-
   /**
-   * Formats the yaml objects into a single string.
-   * @param docs The set of objects
-   * @returns The formatted string
+   * @deprecated use `stringify(doc[, doc, ...])`
    */
-
   public static formatObjects(docs: any[]): string {
-    // convert each resource to yaml and separate with a '---' line
-    // NOTE: we convert undefined values to null, but ignore any documents that
-    //  are undefined
-    const data = docs.map(
-      r => r === undefined ? '\n' : Yaml.stringify(r),
-    ).join('---\n');
-
-    return data;
+    return this.stringify(...docs);
   }
 
   /**
@@ -39,17 +28,23 @@ export class Yaml {
    * @param docs The set of objects
    */
   public static save(filePath: string, docs: any[]) {
-    const data = this.formatObjects(docs);
+    const data = this.stringify(...docs);
     fs.writeFileSync(filePath, data, { encoding: 'utf8' });
   }
 
   /**
-   * Stringify a document into yaml
-   * @param doc An object
+   * Stringify a document (or multiple documents) into YAML
+   *
+   * We convert undefined values to null, but ignore any documents that are
+   * undefined.
+   *
+   * @param docs A set of objects to convert to YAML
+   * @returns a YAML string. Multiple docs are separated by `---`.
    */
-  public static stringify(doc: any) {
-    // Disable lineWidth to avoid loosing the \n into a multi-line parameter with long lines.
-    return YAML.stringify(doc, { keepUndefined: true, lineWidth: 0 });
+  public static stringify(...docs: any[]) {
+    return docs.map(
+      r => r === undefined ? '\n' : YAML.stringify(r, { keepUndefined: true, lineWidth: 0 }),
+    ).join('---\n');
   }
 
   /**

--- a/test/yaml.test.ts
+++ b/test/yaml.test.ts
@@ -107,3 +107,16 @@ test('multi-line text block with long line keep line break', () => {
   };
   expect(Yaml.stringify(yamlString)).toMatchSnapshot();
 });
+
+test('stringify() accepts multiple documents', () => {
+  const actual = Yaml.stringify({ foo: 123 }, { bar: ['hi', 'there'], jam: 12 });
+  expect(actual).toStrictEqual([
+    'foo: 123',
+    '---',
+    'bar:',
+    '  - hi',
+    '  - there',
+    'jam: 12',
+    '',
+  ].join('\n'));
+});


### PR DESCRIPTION
Following up on #135 - move the logic of `Yaml.formatObjects()` into `Yaml.stringify()` which now accepts a variadic array of objects.

Added a test and deprecate `Yaml.formatObjects()`.

