### PR TITLE
feat: upgrade to constructs v10

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -25,6 +25,7 @@
     },
     {
       "name": "constructs",
+      "version": "10.0.0",
       "type": "build"
     },
     {
@@ -114,6 +115,7 @@
     },
     {
       "name": "constructs",
+      "version": "^10.0.0",
       "type": "peer"
     }
   ],

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -10,7 +10,7 @@ const project = new cdk.JsiiProject({
   authorUrl: 'https://aws.amazon.com',
 
   peerDeps: [
-    'constructs',
+    'constructs@^10.0.0',
   ],
 
   bundledDeps: [

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/node": "^12.13.0",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "constructs": "^3.3.162",
+    "constructs": "10.0.0",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^2.5.0",
@@ -64,7 +64,7 @@
     "typescript": "^4.5.2"
   },
   "peerDependencies": {
-    "constructs": "^3.3.162"
+    "constructs": "^10.0.0"
   },
   "dependencies": {
     "fast-json-patch": "^2.2.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -176,19 +176,16 @@ export class App extends Construct {
   public synthYaml(): any {
     validate(this);
 
-    var yamls: string[] = [];
     const charts = this.charts;
+    const docs: any[] = [];
 
     for (const chart of charts) {
       const apiObjects = chartToKube(chart);
-
-      yamls.push(Yaml.formatObjects(apiObjects.map((apiObject) => apiObject.toJson())));
+      docs.push(...apiObjects.map(apiObject => apiObject.toJson()));
     }
 
-    yamls = yamls.filter((a) => a); // removes empty elements in array
-    return yamls.join('---\n'); // still need to do this since the yaml formatObjects does not add a --- at the end of every object
+    return Yaml.stringify(...docs);
   }
-
 }
 
 function validate(app: App) {

--- a/src/dependency.ts
+++ b/src/dependency.ts
@@ -37,8 +37,15 @@ export class DependencyGraph {
       putVertex(n);
     }
 
+    const deps = node.findAll().map(n => n.node.dependencies.map(ndep => {
+      return {
+        source: n,
+        target: ndep,
+      };
+    })).flat();
+
     // create all the edges of the graph.
-    for (const dep of node.dependencies) {
+    for (const dep of deps) {
 
       if (!getVertex(dep.target)) {
         // dont cross scope boundaries.

--- a/test/api-object.test.ts
+++ b/test/api-object.test.ts
@@ -1,4 +1,4 @@
-import { Construct, Node, Dependency } from 'constructs';
+import { Construct, Node } from 'constructs';
 import { ApiObject, Chart, JsonPatch, Testing } from '../src';
 
 test('minimal configuration', () => {
@@ -78,18 +78,12 @@ test('addDependency', () => {
 
   obj1.addDependency(obj2, obj3);
 
-  const dependencies: Set<Dependency> = new Set<Dependency>(Node.of(obj1).dependencies);
+  const dependencies = Node.of(obj1).dependencies;
 
-  expect(dependencies).toEqual(new Set<Dependency>([
-    {
-      source: obj1,
-      target: obj2,
-    },
-    {
-      source: obj1,
-      target: obj3,
-    },
-  ]));
+  expect(dependencies).toEqual([
+    obj2,
+    obj3,
+  ]);
 
 });
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -242,11 +242,9 @@ test('synth calls validate', () => {
 
     constructor(scope: Construct, id: string) {
       super(scope, id);
-    }
-
-    protected onValidate(): string[] {
-      this.validateInvoked = true;
-      return [];
+      this.node.addValidation({
+        validate: (): string[] => { this.validateInvoked = true; return [];},
+      });
     }
   }
 

--- a/test/chart.test.ts
+++ b/test/chart.test.ts
@@ -1,4 +1,4 @@
-import { Construct, Node, Dependency } from 'constructs';
+import { Construct, Node } from 'constructs';
 import { Chart, ApiObject, Testing } from '../src';
 import { Lazy } from '../src/lazy';
 
@@ -103,18 +103,12 @@ test('addDependency', () => {
 
   chart1.addDependency(chart2, chart3);
 
-  const dependencies: Set<Dependency> = new Set<Dependency>(Node.of(chart1).dependencies);
+  const dependencies = Node.of(chart1).dependencies;
 
-  expect(dependencies).toEqual(new Set<Dependency>([
-    {
-      source: chart1,
-      target: chart2,
-    },
-    {
-      source: chart1,
-      target: chart3,
-    },
-  ]));
+  expect(dependencies).toEqual([
+    chart2,
+    chart3,
+  ]);
 
 });
 
@@ -127,11 +121,9 @@ describe('toJson', () => {
 
       constructor(scope: Construct, id: string) {
         super(scope, id);
-      }
-
-      protected onValidate(): string[] {
-        this.validateInvoked = true;
-        return [];
+        this.node.addValidation({
+          validate: (): string[] => {this.validateInvoked = true; return []; },
+        });
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1629,10 +1629,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-constructs@^3.3.162:
-  version "3.3.162"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.162.tgz#c87e0fe75f533353ff9d156028ee765542821980"
-  integrity sha512-ODzbe3frWuIyIhBJs86pqWQWQYFRHHiM0DW4mnJcFgrMn6pyt2viUaAy38RFLDIGrlejy2oOFrEaOArx/CqFRw==
+constructs@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.0.tgz#a6d498540111f6d75663711d0fa65f32fc8f1786"
+  integrity sha512-MIwjmrXZpM9RtwyrSD4HotDIQl8HTdIefQhU+MU1asvtSyVN3kK8kjeUOWMFb+fdyT4RX3QvvcaaPBluLEX1SA==
 
 conventional-changelog-angular@^5.0.12:
   version "5.0.13"


### PR DESCRIPTION
Creating this PR to open a conversation around upgrading `cdk8s` to version 10 of the `constructs` library.

In the current state, the PR introduces a **BREAKING CHANGE**

Looking at [this issue](https://github.com/cdk8s-team/cdk8s/issues/773), @iliapolo mentions the possibility of creating a compatibility layer to support both `constructs` v3 and v10 simultaneously. However I'm not quite sure how that could be implemented.
Is there an example of such thing being done in the past I could refer to?

