### PR TITLE
chore: 1.x branch on the go target

### DIFF
--- a/.github/workflows/release-1.x.yml
+++ b/.github/workflows/release-1.x.yml
@@ -310,6 +310,7 @@ jobs:
       - name: Release
         run: npx -p jsii-release@latest jsii-release-golang
         env:
+          GIT_BRANCH: 1.x
           GIT_USER_NAME: cdk8s-automation
           GIT_USER_EMAIL: cdk8s-team@amazon.com
           GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,6 +310,7 @@ jobs:
       - name: Release
         run: npx -p jsii-release@latest jsii-release-golang
         env:
+          GIT_BRANCH: 1.x
           GIT_USER_NAME: cdk8s-automation
           GIT_USER_EMAIL: cdk8s-team@amazon.com
           GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -63,6 +63,7 @@ const project = new cdk.JsiiProject({
   publishToGo: {
     gitUserName: 'cdk8s-automation',
     gitUserEmail: 'cdk8s-team@amazon.com',
+    gitBranch: '1.x',
     moduleName: 'github.com/cdk8s-team/cdk8s-core-go',
   },
   autoApproveOptions: {


### PR DESCRIPTION
Go publishing currently doesn't specify a target branch for the go repository. 

This was ok when only one major version was published, but since we've started publishing `2.x`, it means that the `main` branch on the go repository has interleaving commits, representing different major versions. 

https://github.com/cdk8s-team/cdk8s-core-go/commits/main

This isn't catastrophic because the tags are still created with a version specifier. It does however introduce a race condition that can fail the go publishing job:

```console
[main c55a9c5] chore(release): v1.3.22
 8 files changed, 258 insertions(+), 138 deletions(-)
 create mode 100644 cdk8s/jsii/cdk8s-1.3.22.tgz
 delete mode 100644 cdk8s/jsii/cdk8s-2.0.18.tgz
To https://github.com/cdk8s-team/cdk8s-core-go.git
 * [new tag]         cdk8s/v1.3.22 -> cdk8s/v1.3.22
To https://github.com/cdk8s-team/cdk8s-core-go.git
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'https://github.com/cdk8s-team/cdk8s-core-go.git'
hint: Updates were rejected because t
```

The local branch isn't up to date because the `2.x` publishing job was running in parallel, updating the `main` branch of the target repo after the local clone has been made. 

The fix is to specify a different branch for every major version. 

Signed-off-by: iliapolo <epolon@amazon.com>
