### PR TITLE
feat: yaml output type FOLDER_PER_CHART_FILE_PER_RESOURCE

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -2432,3 +2432,10 @@ Each resource is output to its own file.
 
 ---
 
+
+#### `FOLDER_PER_CHART_FILE_PER_RESOURCE` <a name="org.cdk8s.YamlOutputType.FOLDER_PER_CHART_FILE_PER_RESOURCE"></a>
+
+Each chart in its own folder and each resource in its own file.
+
+---
+

--- a/docs/python.md
+++ b/docs/python.md
@@ -2706,3 +2706,10 @@ Each resource is output to its own file.
 
 ---
 
+
+#### `FOLDER_PER_CHART_FILE_PER_RESOURCE` <a name="cdk8s.YamlOutputType.FOLDER_PER_CHART_FILE_PER_RESOURCE"></a>
+
+Each chart in its own folder and each resource in its own file.
+
+---
+

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2157,3 +2157,10 @@ Each resource is output to its own file.
 
 ---
 
+
+#### `FOLDER_PER_CHART_FILE_PER_RESOURCE` <a name="cdk8s.YamlOutputType.FOLDER_PER_CHART_FILE_PER_RESOURCE"></a>
+
+Each chart in its own folder and each resource in its own file.
+
+---
+

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,8 @@ export enum YamlOutputType {
   FILE_PER_CHART,
   /** Each resource is output to its own file */
   FILE_PER_RESOURCE,
+  /** Each chart in its own folder and each resource in its own file */
+  FOLDER_PER_CHART_FILE_PER_RESOURCE,
 }
 
 export interface AppProps {
@@ -162,6 +164,24 @@ export class App extends Construct {
         }
         break;
 
+      case YamlOutputType.FOLDER_PER_CHART_FILE_PER_RESOURCE:
+        const folderNamer: ChartNamer = hasDependantCharts ? new IndexedChartFolderNamer() : new SimpleChartFolderNamer();
+        for (const chart of charts) {
+          const chartName = folderNamer.name(chart);
+          const apiObjects = chartToKube(chart);
+          const fullOutDir = path.join(this.outdir, chartName);
+          fs.mkdirSync(fullOutDir, { recursive: true });
+
+          apiObjects.forEach((apiObject) => {
+            if (!(apiObject === undefined)) {
+              const fileName = `${`${apiObject.kind}.${apiObject.metadata.name}`
+                .replace(/[^0-9a-zA-Z-_.]/g, '')}.k8s.yaml`;
+              Yaml.save(path.join(fullOutDir, fileName), [apiObject.toJson()]);
+            }
+          });
+        }
+        break;
+
       default:
         break;
     }
@@ -274,6 +294,28 @@ class SimpleChartNamer implements ChartNamer {
 }
 
 class IndexedChartNamer extends SimpleChartNamer implements ChartNamer {
+  private index: number = 0;
+  constructor() {
+    super();
+  }
+
+  public name(chart: Chart) {
+    const name = `${this.index.toString().padStart(4, '0')}-${super.name(chart)}`;
+    this.index++;
+    return name;
+  }
+}
+
+class SimpleChartFolderNamer implements ChartNamer {
+  constructor() {
+  }
+
+  public name(chart: Chart) {
+    return Names.toDnsLabel(chart);
+  }
+}
+
+class IndexedChartFolderNamer extends SimpleChartFolderNamer implements ChartNamer {
   private index: number = 0;
   constructor() {
     super();

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -273,6 +273,10 @@ test('apps with varying yamlOutputTypes; two charts, no objects', () => {
       props: { yamlOutputType: YamlOutputType.FILE_PER_RESOURCE },
       result: [],
     },
+    {
+      props: { yamlOutputType: YamlOutputType.FOLDER_PER_CHART_FILE_PER_RESOURCE },
+      result: ['chart1', 'chart2'],
+    },
   ];
   for (const testSpec of testSpecs) {
     // GIVEN
@@ -332,6 +336,14 @@ test('apps with varying yamlOutputTypes; charts indirectly dependant, multiple o
         'Kind3.chart3-obj3-c8abbfb5.k8s.yaml',
       ],
     },
+    {
+      props: { yamlOutputType: YamlOutputType.FOLDER_PER_CHART_FILE_PER_RESOURCE },
+      result: [
+        '0000-chart3/Kind3.chart3-obj3-c8abbfb5.k8s.yaml',
+        '0001-chart2/Kind2.chart2-obj2-c8636f20.k8s.yaml',
+        '0002-chart1/Kind1.chart1-obj1-c818e77f.k8s.yaml',
+      ],
+    },
   ];
 
   for (const testSpec of testSpecs) {
@@ -353,7 +365,7 @@ test('apps with varying yamlOutputTypes; charts indirectly dependant, multiple o
     app.synth();
 
     // THEN
-    expect(fs.readdirSync(app.outdir)).toEqual(testSpec.result);
+    expect(getFilesAndFolders(app.outdir)).toEqual(testSpec.result);
   }
 });
 
@@ -386,6 +398,13 @@ test('apps with varying yamlOutputTypes; chart dependencies via custom construct
         'CustomConstruct.chart2-database-databaseobj-c8b5eba3.k8s.yaml',
       ],
     },
+    {
+      props: { yamlOutputType: YamlOutputType.FOLDER_PER_CHART_FILE_PER_RESOURCE },
+      result: [
+        '0000-chart2/CustomConstruct.chart2-database-databaseobj-c8b5eba3.k8s.yaml',
+        '0001-chart1/CustomConstruct.chart1-microservice-microserviceobj-c8e1164f.k8s.yaml',
+      ],
+    },
   ];
 
   for (const testSpec of testSpecs) {
@@ -400,6 +419,26 @@ test('apps with varying yamlOutputTypes; chart dependencies via custom construct
 
     app.synth();
 
-    expect(fs.readdirSync(app.outdir)).toEqual(testSpec.result);
+    expect(getFilesAndFolders(app.outdir)).toEqual(testSpec.result);
   }
 });
+
+/**
+ * Get the list of files and folders in the source folder and sub folders (one level deep)
+ * @param sourceDir Folder in which to search for files and folders
+ */
+function getFilesAndFolders(sourceDir: string) {
+  let result = [];
+  let items = fs.readdirSync(sourceDir);
+  for (const item of items) {
+    if (fs.lstatSync(path.join(sourceDir, item)).isDirectory()) {
+      let subFoldersContents = fs.readdirSync(path.join(sourceDir, item));
+      if (subFoldersContents.length > 0) {
+        result.push( ...subFoldersContents.map(file => item + '/' + file));
+      }
+    } else {
+      result.push(item);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Replaces PR # 143

### New feature:

Allows users to elect to export their yaml resources as follows:

Each chart creates a folder
Each resource is created as a file and placed in the correct chart folder
This provides better organization and flexibility as the number of resources created increases.

### Modifications

There are two files modified:

app.ts: Created the new yaml output type and implemented the logic to create the yaml files
app.test.ts: Added additional test cases to verify new functionality
All tests passed locally before submitting PR

New tests use generic helper method that lists all files in each chart folder
(i.e.:'0000-chart2/CustomConstruct.chart2-database-databaseobj-c8b5eba3.k8s.yaml')

Updated test loops to use "for of" rather than "for in" in new test
