### PR TITLE
feat: Allow configuration of output YAML file extensions

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -204,6 +204,7 @@ import org.cdk8s.App;
 
 App.Builder.create()
 //  .outdir(java.lang.String)
+//  .outputFileExtension(java.lang.String)
 //  .yamlOutputType(YamlOutputType)
     .build();
 ```
@@ -214,6 +215,15 @@ App.Builder.create()
 - *Default:* CDK8S_OUTDIR if defined, otherwise "dist"
 
 The directory to output Kubernetes manifests.
+
+---
+
+##### `outputFileExtension`<sup>Optional</sup> <a name="org.cdk8s.AppProps.parameter.outputFileExtension"></a>
+
+- *Type:* `java.lang.String`
+- *Default:* .k8s.yaml
+
+The file extension to use for rendered YAML files.
 
 ---
 
@@ -264,6 +274,19 @@ public java.lang.String getOutdir();
 - *Type:* `java.lang.String`
 
 The output directory into which manifests will be synthesized.
+
+---
+
+##### `outputFileExtension`<sup>Required</sup> <a name="org.cdk8s.App.property.outputFileExtension"></a>
+
+```java
+public java.lang.String getOutputFileExtension();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* .k8s.yaml
+
+The file extension to use for rendered YAML files.
 
 ---
 
@@ -780,6 +803,7 @@ import org.cdk8s.AppProps;
 
 AppProps.builder()
 //  .outdir(java.lang.String)
+//  .outputFileExtension(java.lang.String)
 //  .yamlOutputType(YamlOutputType)
     .build();
 ```
@@ -794,6 +818,19 @@ public java.lang.String getOutdir();
 - *Default:* CDK8S_OUTDIR if defined, otherwise "dist"
 
 The directory to output Kubernetes manifests.
+
+---
+
+##### `outputFileExtension`<sup>Optional</sup> <a name="org.cdk8s.AppProps.property.outputFileExtension"></a>
+
+```java
+public java.lang.String getOutputFileExtension();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* .k8s.yaml
+
+The file extension to use for rendered YAML files.
 
 ---
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -212,6 +212,7 @@ import cdk8s
 
 cdk8s.App(
   outdir: str = None,
+  output_file_extension: str = None,
   yaml_output_type: YamlOutputType = None
 )
 ```
@@ -222,6 +223,15 @@ cdk8s.App(
 - *Default:* CDK8S_OUTDIR if defined, otherwise "dist"
 
 The directory to output Kubernetes manifests.
+
+---
+
+##### `output_file_extension`<sup>Optional</sup> <a name="cdk8s.AppProps.parameter.output_file_extension"></a>
+
+- *Type:* `str`
+- *Default:* .k8s.yaml
+
+The file extension to use for rendered YAML files.
 
 ---
 
@@ -272,6 +282,19 @@ outdir: str
 - *Type:* `str`
 
 The output directory into which manifests will be synthesized.
+
+---
+
+##### `output_file_extension`<sup>Required</sup> <a name="cdk8s.App.property.output_file_extension"></a>
+
+```python
+output_file_extension: str
+```
+
+- *Type:* `str`
+- *Default:* .k8s.yaml
+
+The file extension to use for rendered YAML files.
 
 ---
 
@@ -800,6 +823,7 @@ import cdk8s
 
 cdk8s.AppProps(
   outdir: str = None,
+  output_file_extension: str = None,
   yaml_output_type: YamlOutputType = None
 )
 ```
@@ -814,6 +838,19 @@ outdir: str
 - *Default:* CDK8S_OUTDIR if defined, otherwise "dist"
 
 The directory to output Kubernetes manifests.
+
+---
+
+##### `output_file_extension`<sup>Optional</sup> <a name="cdk8s.AppProps.property.output_file_extension"></a>
+
+```python
+output_file_extension: str
+```
+
+- *Type:* `str`
+- *Default:* .k8s.yaml
+
+The file extension to use for rendered YAML files.
 
 ---
 
@@ -2484,6 +2521,7 @@ import cdk8s
 
 cdk8s.Testing.app(
   outdir: str = None,
+  output_file_extension: str = None,
   yaml_output_type: YamlOutputType = None
 )
 ```
@@ -2494,6 +2532,15 @@ cdk8s.Testing.app(
 - *Default:* CDK8S_OUTDIR if defined, otherwise "dist"
 
 The directory to output Kubernetes manifests.
+
+---
+
+###### `output_file_extension`<sup>Optional</sup> <a name="cdk8s.AppProps.parameter.output_file_extension"></a>
+
+- *Type:* `str`
+- *Default:* .k8s.yaml
+
+The file extension to use for rendered YAML files.
 
 ---
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -231,6 +231,19 @@ The output directory into which manifests will be synthesized.
 
 ---
 
+##### `outputFileExtension`<sup>Required</sup> <a name="cdk8s.App.property.outputFileExtension"></a>
+
+```typescript
+public readonly outputFileExtension: string;
+```
+
+- *Type:* `string`
+- *Default:* .k8s.yaml
+
+The file extension to use for rendered YAML files.
+
+---
+
 ##### `yamlOutputType`<sup>Required</sup> <a name="cdk8s.App.property.yamlOutputType"></a>
 
 ```typescript
@@ -674,6 +687,19 @@ public readonly outdir: string;
 - *Default:* CDK8S_OUTDIR if defined, otherwise "dist"
 
 The directory to output Kubernetes manifests.
+
+---
+
+##### `outputFileExtension`<sup>Optional</sup> <a name="cdk8s.AppProps.property.outputFileExtension"></a>
+
+```typescript
+public readonly outputFileExtension: string;
+```
+
+- *Type:* `string`
+- *Default:* .k8s.yaml
+
+The file extension to use for rendered YAML files.
 
 ---
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,7 +26,13 @@ export interface AppProps {
    * @default - CDK8S_OUTDIR if defined, otherwise "dist"
    */
   readonly outdir?: string;
-  /** How to divide the YAML output into files
+  /**
+   *  The file extension to use for rendered YAML files
+   * @default .k8s.yaml
+   */
+  readonly outputFileExtension?: string;
+  /**
+   *  How to divide the YAML output into files
    * @default YamlOutputType.FILE_PER_CHART
    */
   readonly yamlOutputType?: YamlOutputType;
@@ -82,6 +88,12 @@ export class App extends Construct {
    */
   public readonly outdir: string;
 
+  /**
+   *  The file extension to use for rendered YAML files
+   * @default .k8s.yaml
+   */
+  public readonly outputFileExtension: string;
+
   /** How to divide the YAML output into files
    * @default YamlOutputType.FILE_PER_CHART
    */
@@ -104,6 +116,7 @@ export class App extends Construct {
   constructor(props: AppProps = { }) {
     super(undefined as any, '');
     this.outdir = props.outdir ?? process.env.CDK8S_OUTDIR ?? 'dist';
+    this.outputFileExtension = props.outputFileExtension ?? '.k8s.yaml';
     this.yamlOutputType = props.yamlOutputType ?? YamlOutputType.FILE_PER_CHART;
   }
 
@@ -133,7 +146,7 @@ export class App extends Construct {
 
         if (charts.length > 0) {
           Yaml.save(
-            path.join(this.outdir, 'app.k8s.yaml'), // There is no "app name", so we just hardcode the file name
+            path.join(this.outdir, `app${this.outputFileExtension}`), // There is no "app name", so we just hardcode the file name
             apiObjectList.map((apiObject) => apiObject.toJson()),
           );
         }
@@ -146,7 +159,7 @@ export class App extends Construct {
           const chartName = namer.name(chart);
           const objects = chartToKube(chart);
 
-          Yaml.save(path.join(this.outdir, chartName), objects.map(obj => obj.toJson()));
+          Yaml.save(path.join(this.outdir, chartName+this.outputFileExtension), objects.map(obj => obj.toJson()));
         }
         break;
 
@@ -157,8 +170,8 @@ export class App extends Construct {
           apiObjects.forEach((apiObject) => {
             if (!(apiObject === undefined)) {
               const fileName = `${`${apiObject.kind}.${apiObject.metadata.name}`
-                .replace(/[^0-9a-zA-Z-_.]/g, '')}.k8s.yaml`;
-              Yaml.save(path.join(this.outdir, fileName), [apiObject.toJson()]);
+                .replace(/[^0-9a-zA-Z-_.]/g, '')}`;
+              Yaml.save(path.join(this.outdir, fileName+this.outputFileExtension), [apiObject.toJson()]);
             }
           });
         }
@@ -175,8 +188,8 @@ export class App extends Construct {
           apiObjects.forEach((apiObject) => {
             if (!(apiObject === undefined)) {
               const fileName = `${`${apiObject.kind}.${apiObject.metadata.name}`
-                .replace(/[^0-9a-zA-Z-_.]/g, '')}.k8s.yaml`;
-              Yaml.save(path.join(fullOutDir, fileName), [apiObject.toJson()]);
+                .replace(/[^0-9a-zA-Z-_.]/g, '')}`;
+              Yaml.save(path.join(fullOutDir, fileName+this.outputFileExtension), [apiObject.toJson()]);
             }
           });
         }
@@ -289,7 +302,7 @@ class SimpleChartNamer implements ChartNamer {
   }
 
   public name(chart: Chart) {
-    return `${Names.toDnsLabel(chart)}.k8s.yaml`;
+    return `${Names.toDnsLabel(chart)}`;
   }
 }
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -423,6 +423,40 @@ test('apps with varying yamlOutputTypes; chart dependencies via custom construct
   }
 });
 
+test('Modified file extensions with varying output types; two charts, no objects', () => {
+  const testSpecs = [
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_CHART, outputFileExtension: '.yaml' },
+      result: ['chart1.yaml', 'chart2.yaml'],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_APP, outputFileExtension: '.yaml' },
+      result: ['app.yaml'],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_RESOURCE, outputFileExtension: '.yaml' },
+      result: [],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FOLDER_PER_CHART_FILE_PER_RESOURCE, outputFileExtension: '.yaml' },
+      result: ['chart1', 'chart2'],
+    },
+  ];
+  for (const testSpec of testSpecs) {
+    // GIVEN
+    const app = Testing.app(testSpec.props);
+
+    // WHEN
+    new Chart(app, 'chart1');
+    new Chart(app, 'chart2');
+    app.synth();
+
+    // THEN
+    expect(fs.readdirSync(app.outdir)).toEqual(testSpec.result);
+  }
+});
+
+
 /**
  * Get the list of files and folders in the source folder and sub folders (one level deep)
  * @param sourceDir Folder in which to search for files and folders


### PR DESCRIPTION
Fixes #296 

I've retained the current behavior as the default, and added a prop to `App` to allow configuration of the file extensions applied to the outputted YAML.

Please just let me know if you'd like any more information or if I need to make any changes!