### PR TITLE
fix: Chart.of does not recognize valid charts

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -388,6 +388,20 @@ public toJson()
 
 #### Static Functions <a name="Static Functions"></a>
 
+##### `isChart` <a name="org.cdk8s.Chart.isChart"></a>
+
+```java
+import org.cdk8s.Chart;
+
+Chart.isChart(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="org.cdk8s.Chart.parameter.x"></a>
+
+- *Type:* `java.lang.Object`
+
+---
+
 ##### `of` <a name="org.cdk8s.Chart.of"></a>
 
 ```java

--- a/docs/python.md
+++ b/docs/python.md
@@ -402,6 +402,22 @@ def to_json()
 
 #### Static Functions <a name="Static Functions"></a>
 
+##### `is_chart` <a name="cdk8s.Chart.is_chart"></a>
+
+```python
+import cdk8s
+
+cdk8s.Chart.is_chart(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="cdk8s.Chart.parameter.x"></a>
+
+- *Type:* `typing.Any`
+
+---
+
 ##### `of` <a name="cdk8s.Chart.of"></a>
 
 ```python

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -324,6 +324,20 @@ public toJson()
 
 #### Static Functions <a name="Static Functions"></a>
 
+##### `isChart` <a name="cdk8s.Chart.isChart"></a>
+
+```typescript
+import { Chart } from 'cdk8s'
+
+Chart.isChart(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="cdk8s.Chart.parameter.x"></a>
+
+- *Type:* `any`
+
+---
+
 ##### `of` <a name="cdk8s.Chart.of"></a>
 
 ```typescript

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -3,6 +3,8 @@ import { ApiObject } from './api-object';
 import { App } from './app';
 import { Names } from './names';
 
+const CHART_SYMBOL = Symbol.for('cdk8s.Chart');
+
 export interface ChartProps {
   /**
    * The default namespace for all objects defined in this chart (directly or
@@ -22,13 +24,21 @@ export interface ChartProps {
 }
 
 export class Chart extends Construct {
+  /**
+   * Return whether the given object is a Chart.
+   *
+   * We do attribute detection since we can't reliably use 'instanceof'.
+   */
+  public static isChart(x: any): x is Chart {
+    return x !== null && typeof(x) === 'object' && CHART_SYMBOL in x;
+  }
 
   /**
    * Finds the chart in which a node is defined.
    * @param c a construct node
    */
   public static of(c: IConstruct): Chart {
-    if (c instanceof Chart) {
+    if (Chart.isChart(c)) {
       return c;
     }
 
@@ -54,6 +64,8 @@ export class Chart extends Construct {
     super(scope, id);
     this.namespace = props.namespace;
     this._labels = props.labels ?? {};
+
+    Object.defineProperty(this, CHART_SYMBOL, { value: true });
   }
 
   /**

--- a/test/chart.test.ts
+++ b/test/chart.test.ts
@@ -112,6 +112,31 @@ test('addDependency', () => {
 
 });
 
+test('isChart distinguishes charts from non-charts', () => {
+  // GIVEN
+  const app = Testing.app();
+
+  class MyChart extends Chart {
+    constructor(scope: Construct, id: string, props?: any) {
+      super(scope, id, props);
+    }
+  }
+
+  // WHEN
+  const chart = new Chart(app, 'chart');
+  const childChart = new MyChart(app, 'my-chart');
+  const obj = new ApiObject(chart, 'api-object', {
+    apiVersion: 'v1',
+    kind: 'Foo',
+  });
+
+  // THEN
+  expect(Chart.isChart(chart)).toEqual(true);
+  expect(Chart.isChart(childChart)).toEqual(true);
+  expect(Chart.isChart(obj)).toEqual(false);
+  expect(Chart.isChart(app)).toEqual(false);
+});
+
 describe('toJson', () => {
 
   test('validates the chart', () => {


### PR DESCRIPTION
Fixes #401 

I haven't explicitly tested this with the scenario described in #401 but I believe the root cause is the same issue described [here](https://github.com/aws/constructs/pull/955). In a nutshell, "instanceof" is unreliable since it can cause issues if libraries are referencing different versions of cdk8s library in `node_modules`.

Signed-off-by: Christopher Rybicki <rybickic@amazon.com>