### PR TITLE
feat(lib): sort arrays in sanitizeValue

### DIFF
--- a/src/_util.ts
+++ b/src/_util.ts
@@ -27,13 +27,16 @@ export function sanitizeValue(obj: any, options: SanitizeOptions = { }): any {
     return obj;
   }
 
+  const sortKeys = options.sortKeys ?? true;
+
   if (Array.isArray(obj)) {
 
     if (options.filterEmptyArrays && obj.length === 0) {
       return undefined;
     }
 
-    return obj.map(x => sanitizeValue(x, options));
+    const newArray = obj.map(x => sanitizeValue(x, options));
+    return sortKeys ? newArray.sort() : newArray
   }
 
   if (obj.constructor.name !== 'Object') {
@@ -42,7 +45,6 @@ export function sanitizeValue(obj: any, options: SanitizeOptions = { }): any {
 
   const newObj: { [key: string]: any } = { };
 
-  const sortKeys = options.sortKeys ?? true;
   const keys = sortKeys ? Object.keys(obj).sort() : Object.keys(obj);
   for (const key of keys) {
     const value = obj[key];

--- a/test/__snapshots__/util.test.ts.snap
+++ b/test/__snapshots__/util.test.ts.snap
@@ -24,9 +24,9 @@ exports[`sanitizeValue sortKeys 2`] = `
   \\"nested\\": {
     \\"foo\\": {
       \\"zag\\": [
+        3,
         1,
-        2,
-        3
+        2
       ],
       \\"bar\\": \\"1111\\"
     }

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -14,8 +14,8 @@ describe('sanitizeValue', () => {
     expect(sanitizeValue({ xoo: { }, foo: { bar: { zoo: undefined, hey: { }, me: 123 } } }))
       .toStrictEqual({ xoo: { }, foo: { bar: { hey: { }, me: 123 } } });
     expect(sanitizeValue({ xoo: 123, foo: [1, 2, { foo: 123, bar: undefined, zoo: [] }, 3] }))
-      .toStrictEqual({ xoo: 123, foo: [1, 2, { foo: 123, zoo: [] }, 3] });
-    expect(sanitizeValue([1, 2, 3, [], { }, 4])).toStrictEqual([1, 2, 3, [], { }, 4]); // special case
+      .toStrictEqual({ xoo: 123, foo: [1, 2, 3, { foo: 123, zoo: [] }] });
+    expect(sanitizeValue([1, 2, 3, [], { }, 4])).toStrictEqual([[], 1, 2, 3, 4, { }]); // special case
 
     expect(() => sanitizeValue(new Dummy())).toThrow(/can't render non-simple object of type 'Dummy'/);
   });
@@ -41,7 +41,7 @@ describe('sanitizeValue', () => {
   });
 
   test('sortKeys', () => {
-    const input = { zzz: 999, aaa: 111, nested: { foo: { zag: [1, 2, 3], bar: '1111' } } };
+    const input = { zzz: 999, aaa: 111, nested: { foo: { zag: [3, 1, 2], bar: '1111' } } };
     expect(str(sanitizeValue(input))).toMatchSnapshot();
     expect(str(sanitizeValue(input, { sortKeys: false }))).toMatchSnapshot();
   });


### PR DESCRIPTION
# Context:
When running `cdk8s synth` yaml configuration files are dump on file system. Between 2 runs, it is possible that unordered lists are generated differently, such as:
````
diff -Nru run1.yaml run2.yaml
--- run1.yaml	2022-04-22 11:41:11.501694751 +0000
+++ run2.yaml	2022-04-22 11:41:32.721834049 +0000
@@ -488,11 +488,6 @@
               env:
-                - name: MY_CUSTOM_VAR_A
-                  value: "foobar_a"
                 - name: MY_CUSTOM_VAR_B
                   value: "foobar_b"
+                - name: MY_CUSTOM_VAR_A
+                  value: "foobar_a"
                 - name: MY_CUSTOM_VAR_C
                   value: "foobar_c"
````

# Expected:
This should not happen and all lists should be ordered and generated the same way on multiple runs.

# Proposed solution:

- Sort arrays
- Use the existing flag `CDK8S_DISABLE_SORT` to disable sort