### PR TITLE
Do not ignore /src - this breaks sourcemaps

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,7 +8,6 @@ junit.xml
 /.mergify.yml
 /test/
 /tsconfig.dev.json
-/src/
 !/lib/
 !/lib/**/*.js
 !/lib/**/*.d.ts


### PR DESCRIPTION
Sourcemaps are broken when the sources are not included in the npm package. This makes it hard to dive deep into errors encountered while writing charts if such errors occur.
