### PR TITLE
chore: add manually generated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,996 @@
+## [0.0.0](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.17...v0.0.0) (2022-08-31)
+
+### [2.4.17](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.16...v2.4.17) (2022-08-31)
+
+### [2.4.16](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.15...v2.4.16) (2022-08-30)
+
+### [2.4.15](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.14...v2.4.15) (2022-08-29)
+
+
+### Bug Fixes
+
+* align schedule class to K8s cron requirements ([#705](https://github.com/cdk8s-team/cdk8s-core/issues/705)) ([54e04a8](https://github.com/cdk8s-team/cdk8s-core/commit/54e04a84c5da04b1a144f9b209f0ea9ea567b5d5))
+
+### [2.4.14](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.13...v2.4.14) (2022-08-29)
+
+### [2.4.13](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.12...v2.4.13) (2022-08-28)
+
+### [2.4.12](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.11...v2.4.12) (2022-08-27)
+
+### [2.4.11](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.10...v2.4.11) (2022-08-26)
+
+### [2.4.10](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.9...v2.4.10) (2022-08-25)
+
+### [2.4.9](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.8...v2.4.9) (2022-08-24)
+
+### [2.4.8](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.7...v2.4.8) (2022-08-23)
+
+### [2.4.7](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.6...v2.4.7) (2022-08-22)
+
+### [2.4.6](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.5...v2.4.6) (2022-08-21)
+
+### [2.4.5](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.4...v2.4.5) (2022-08-20)
+
+### [2.4.4](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.3...v2.4.4) (2022-08-19)
+
+### [2.4.3](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.2...v2.4.3) (2022-08-18)
+
+### [2.4.2](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.1...v2.4.2) (2022-08-17)
+
+### [2.4.1](https://github.com/cdk8s-team/cdk8s-core/compare/v2.4.0...v2.4.1) (2022-08-16)
+
+## [2.4.0](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.84...v2.4.0) (2022-08-15)
+
+
+### Features
+
+* schedule class ([#637](https://github.com/cdk8s-team/cdk8s-core/issues/637)) ([20a077e](https://github.com/cdk8s-team/cdk8s-core/commit/20a077e7deffa30d12d413a83413947170fba6e5))
+
+### [2.3.84](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.83...v2.3.84) (2022-08-15)
+
+### [2.3.83](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.82...v2.3.83) (2022-08-14)
+
+### [2.3.82](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.81...v2.3.82) (2022-08-13)
+
+### [2.3.81](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.80...v2.3.81) (2022-08-12)
+
+### [2.3.80](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.79...v2.3.80) (2022-08-11)
+
+### [2.3.79](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.78...v2.3.79) (2022-08-09)
+
+### [2.3.78](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.77...v2.3.78) (2022-08-08)
+
+### [2.3.77](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.76...v2.3.77) (2022-08-07)
+
+### [2.3.76](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.75...v2.3.76) (2022-08-06)
+
+### [2.3.75](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.74...v2.3.75) (2022-08-05)
+
+### [2.3.74](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.73...v2.3.74) (2022-08-03)
+
+### [2.3.73](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.72...v2.3.73) (2022-08-02)
+
+### [2.3.72](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.71...v2.3.72) (2022-08-01)
+
+### [2.3.71](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.70...v2.3.71) (2022-07-31)
+
+### [2.3.70](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.69...v2.3.70) (2022-07-30)
+
+### [2.3.69](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.68...v2.3.69) (2022-07-29)
+
+### [2.3.68](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.67...v2.3.68) (2022-07-28)
+
+### [2.3.67](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.66...v2.3.67) (2022-07-27)
+
+### [2.3.66](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.65...v2.3.66) (2022-07-26)
+
+### [2.3.65](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.64...v2.3.65) (2022-07-25)
+
+### [2.3.64](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.63...v2.3.64) (2022-07-24)
+
+### [2.3.63](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.62...v2.3.63) (2022-07-23)
+
+### [2.3.62](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.61...v2.3.62) (2022-07-22)
+
+### [2.3.61](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.60...v2.3.61) (2022-07-21)
+
+### [2.3.60](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.59...v2.3.60) (2022-07-20)
+
+### [2.3.59](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.58...v2.3.59) (2022-07-19)
+
+### [2.3.58](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.57...v2.3.58) (2022-07-18)
+
+### [2.3.57](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.56...v2.3.57) (2022-07-17)
+
+### [2.3.56](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.55...v2.3.56) (2022-07-16)
+
+### [2.3.55](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.54...v2.3.55) (2022-07-15)
+
+### [2.3.54](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.53...v2.3.54) (2022-07-14)
+
+### [2.3.53](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.52...v2.3.53) (2022-07-13)
+
+### [2.3.52](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.51...v2.3.52) (2022-07-12)
+
+### [2.3.51](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.50...v2.3.51) (2022-07-11)
+
+### [2.3.50](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.49...v2.3.50) (2022-07-09)
+
+### [2.3.49](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.48...v2.3.49) (2022-07-08)
+
+### [2.3.48](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.47...v2.3.48) (2022-07-07)
+
+### [2.3.47](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.46...v2.3.47) (2022-07-06)
+
+### [2.3.46](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.45...v2.3.46) (2022-07-06)
+
+### [2.3.45](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.44...v2.3.45) (2022-07-05)
+
+### [2.3.44](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.43...v2.3.44) (2022-07-04)
+
+### [2.3.43](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.42...v2.3.43) (2022-07-03)
+
+### [2.3.42](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.41...v2.3.42) (2022-07-02)
+
+### [2.3.41](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.40...v2.3.41) (2022-06-30)
+
+### [2.3.40](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.39...v2.3.40) (2022-06-29)
+
+### [2.3.39](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.38...v2.3.39) (2022-06-28)
+
+### [2.3.38](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.37...v2.3.38) (2022-06-27)
+
+### [2.3.37](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.36...v2.3.37) (2022-06-26)
+
+### [2.3.36](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.35...v2.3.36) (2022-06-25)
+
+### [2.3.35](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.34...v2.3.35) (2022-06-24)
+
+### [2.3.34](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.33...v2.3.34) (2022-06-23)
+
+### [2.3.33](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.32...v2.3.33) (2022-06-22)
+
+### [2.3.32](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.31...v2.3.32) (2022-06-21)
+
+### [2.3.31](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.30...v2.3.31) (2022-06-18)
+
+### [2.3.30](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.29...v2.3.30) (2022-06-17)
+
+### [2.3.29](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.28...v2.3.29) (2022-06-16)
+
+### [2.3.28](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.27...v2.3.28) (2022-06-15)
+
+### [2.3.27](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.26...v2.3.27) (2022-06-15)
+
+### [2.3.26](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.25...v2.3.26) (2022-06-14)
+
+### [2.3.25](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.24...v2.3.25) (2022-06-13)
+
+### [2.3.24](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.23...v2.3.24) (2022-06-12)
+
+### [2.3.23](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.22...v2.3.23) (2022-06-11)
+
+### [2.3.22](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.21...v2.3.22) (2022-06-10)
+
+### [2.3.21](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.20...v2.3.21) (2022-06-09)
+
+### [2.3.20](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.19...v2.3.20) (2022-06-08)
+
+### [2.3.19](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.18...v2.3.19) (2022-06-07)
+
+### [2.3.18](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.17...v2.3.18) (2022-06-06)
+
+### [2.3.17](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.16...v2.3.17) (2022-06-05)
+
+### [2.3.16](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.15...v2.3.16) (2022-06-04)
+
+### [2.3.15](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.14...v2.3.15) (2022-06-03)
+
+### [2.3.14](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.13...v2.3.14) (2022-06-02)
+
+### [2.3.13](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.12...v2.3.13) (2022-06-01)
+
+### [2.3.12](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.11...v2.3.12) (2022-05-31)
+
+
+### Bug Fixes
+
+* **deps:** upgrade fast-json-patch to v3 ([#510](https://github.com/cdk8s-team/cdk8s-core/issues/510)) ([#511](https://github.com/cdk8s-team/cdk8s-core/issues/511)) ([44fe900](https://github.com/cdk8s-team/cdk8s-core/commit/44fe90069aea4cb72d30415282c8ce92355e1523))
+
+### [2.3.11](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.10...v2.3.11) (2022-05-31)
+
+### [2.3.10](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.9...v2.3.10) (2022-05-30)
+
+### [2.3.9](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.8...v2.3.9) (2022-05-29)
+
+### [2.3.8](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.7...v2.3.8) (2022-05-28)
+
+### [2.3.7](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.6...v2.3.7) (2022-05-27)
+
+### [2.3.6](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.5...v2.3.6) (2022-05-26)
+
+### [2.3.5](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.4...v2.3.5) (2022-05-25)
+
+### [2.3.4](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.3...v2.3.4) (2022-05-24)
+
+### [2.3.3](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.2...v2.3.3) (2022-05-23)
+
+### [2.3.2](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.1...v2.3.2) (2022-05-22)
+
+### [2.3.1](https://github.com/cdk8s-team/cdk8s-core/compare/v2.3.0...v2.3.1) (2022-05-21)
+
+## [2.3.0](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.87...v2.3.0) (2022-05-21)
+
+
+### Features
+
+* require node 14 ([#486](https://github.com/cdk8s-team/cdk8s-core/issues/486)) ([3230a0e](https://github.com/cdk8s-team/cdk8s-core/commit/3230a0e26c7d05a490b6d8151dde424543ec82ac))
+
+### [2.2.87](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.86...v2.2.87) (2022-05-20)
+
+### [2.2.86](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.85...v2.2.86) (2022-05-19)
+
+### [2.2.85](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.84...v2.2.85) (2022-05-02)
+
+### [2.2.84](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.83...v2.2.84) (2022-05-01)
+
+### [2.2.83](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.82...v2.2.83) (2022-04-30)
+
+### [2.2.82](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.81...v2.2.82) (2022-04-29)
+
+### [2.2.81](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.80...v2.2.81) (2022-04-28)
+
+### [2.2.80](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.79...v2.2.80) (2022-04-27)
+
+### [2.2.79](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.78...v2.2.79) (2022-04-26)
+
+### [2.2.78](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.77...v2.2.78) (2022-04-25)
+
+### [2.2.77](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.76...v2.2.77) (2022-04-24)
+
+### [2.2.76](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.75...v2.2.76) (2022-04-23)
+
+### [2.2.75](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.74...v2.2.75) (2022-04-22)
+
+### [2.2.74](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.73...v2.2.74) (2022-04-21)
+
+### [2.2.73](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.72...v2.2.73) (2022-04-20)
+
+### [2.2.72](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.71...v2.2.72) (2022-04-19)
+
+### [2.2.71](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.70...v2.2.71) (2022-04-18)
+
+### [2.2.70](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.69...v2.2.70) (2022-04-17)
+
+### [2.2.69](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.68...v2.2.69) (2022-04-16)
+
+### [2.2.68](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.67...v2.2.68) (2022-04-15)
+
+### [2.2.67](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.66...v2.2.67) (2022-04-14)
+
+### [2.2.66](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.65...v2.2.66) (2022-04-13)
+
+### [2.2.65](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.64...v2.2.65) (2022-04-12)
+
+### [2.2.64](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.63...v2.2.64) (2022-04-11)
+
+### [2.2.63](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.62...v2.2.63) (2022-04-10)
+
+### [2.2.62](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.61...v2.2.62) (2022-04-09)
+
+### [2.2.61](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.60...v2.2.61) (2022-04-07)
+
+### [2.2.60](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.59...v2.2.60) (2022-04-06)
+
+### [2.2.59](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.58...v2.2.59) (2022-04-05)
+
+### [2.2.58](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.57...v2.2.58) (2022-04-04)
+
+### [2.2.57](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.56...v2.2.57) (2022-04-03)
+
+### [2.2.56](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.55...v2.2.56) (2022-04-02)
+
+### [2.2.55](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.54...v2.2.55) (2022-04-01)
+
+### [2.2.54](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.53...v2.2.54) (2022-03-31)
+
+### [2.2.53](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.52...v2.2.53) (2022-03-30)
+
+### [2.2.52](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.51...v2.2.52) (2022-03-29)
+
+
+### Bug Fixes
+
+* Chart.of does not recognize valid charts ([#402](https://github.com/cdk8s-team/cdk8s-core/issues/402)) ([d7322b2](https://github.com/cdk8s-team/cdk8s-core/commit/d7322b27d16507d13149588bbb223cbfce0b556d)), closes [#401](https://github.com/cdk8s-team/cdk8s-core/issues/401) [#401](https://github.com/cdk8s-team/cdk8s-core/issues/401)
+
+### [2.2.51](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.50...v2.2.51) (2022-03-29)
+
+### [2.2.50](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.49...v2.2.50) (2022-03-28)
+
+### [2.2.49](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.48...v2.2.49) (2022-03-27)
+
+### [2.2.48](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.47...v2.2.48) (2022-03-26)
+
+### [2.2.47](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.46...v2.2.47) (2022-03-25)
+
+### [2.2.46](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.45...v2.2.46) (2022-03-24)
+
+### [2.2.45](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.44...v2.2.45) (2022-03-23)
+
+### [2.2.44](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.43...v2.2.44) (2022-03-22)
+
+### [2.2.43](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.42...v2.2.43) (2022-03-18)
+
+### [2.2.42](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.41...v2.2.42) (2022-03-17)
+
+### [2.2.41](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.40...v2.2.41) (2022-03-16)
+
+### [2.2.40](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.39...v2.2.40) (2022-03-15)
+
+### [2.2.39](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.38...v2.2.39) (2022-03-14)
+
+### [2.2.38](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.37...v2.2.38) (2022-03-13)
+
+### [2.2.37](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.36...v2.2.37) (2022-03-12)
+
+### [2.2.36](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.35...v2.2.36) (2022-03-11)
+
+### [2.2.35](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.34...v2.2.35) (2022-03-10)
+
+### [2.2.34](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.33...v2.2.34) (2022-03-09)
+
+### [2.2.33](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.32...v2.2.33) (2022-03-08)
+
+### [2.2.32](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.31...v2.2.32) (2022-03-07)
+
+### [2.2.31](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.30...v2.2.31) (2022-03-06)
+
+### [2.2.30](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.29...v2.2.30) (2022-03-05)
+
+### [2.2.29](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.28...v2.2.29) (2022-03-04)
+
+### [2.2.28](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.27...v2.2.28) (2022-03-03)
+
+### [2.2.27](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.26...v2.2.27) (2022-03-02)
+
+### [2.2.26](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.25...v2.2.26) (2022-03-01)
+
+### [2.2.25](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.24...v2.2.25) (2022-02-27)
+
+### [2.2.24](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.23...v2.2.24) (2022-02-26)
+
+### [2.2.23](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.22...v2.2.23) (2022-02-24)
+
+### [2.2.22](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.21...v2.2.22) (2022-02-21)
+
+### [2.2.21](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.20...v2.2.21) (2022-02-20)
+
+### [2.2.20](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.19...v2.2.20) (2022-02-19)
+
+### [2.2.19](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.18...v2.2.19) (2022-02-18)
+
+### [2.2.18](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.17...v2.2.18) (2022-02-17)
+
+### [2.2.17](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.16...v2.2.17) (2022-02-15)
+
+### [2.2.16](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.15...v2.2.16) (2022-02-14)
+
+### [2.2.15](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.14...v2.2.15) (2022-02-13)
+
+### [2.2.14](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.13...v2.2.14) (2022-02-12)
+
+### [2.2.13](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.12...v2.2.13) (2022-02-11)
+
+### [2.2.12](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.11...v2.2.12) (2022-02-10)
+
+### [2.2.11](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.10...v2.2.11) (2022-02-09)
+
+### [2.2.10](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.9...v2.2.10) (2022-02-08)
+
+### [2.2.9](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.8...v2.2.9) (2022-02-07)
+
+### [2.2.8](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.7...v2.2.8) (2022-02-05)
+
+### [2.2.7](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.6...v2.2.7) (2022-02-04)
+
+### [2.2.6](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.5...v2.2.6) (2022-02-03)
+
+### [2.2.5](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.4...v2.2.5) (2022-02-02)
+
+### [2.2.4](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.3...v2.2.4) (2022-02-01)
+
+### [2.2.3](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.2...v2.2.3) (2022-01-31)
+
+### [2.2.2](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.1...v2.2.2) (2022-01-30)
+
+### [2.2.1](https://github.com/cdk8s-team/cdk8s-core/compare/v2.2.0...v2.2.1) (2022-01-29)
+
+## [2.2.0](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.24...v2.2.0) (2022-01-28)
+
+
+### Features
+
+* Allow configuration of output YAML file extensions ([#297](https://github.com/cdk8s-team/cdk8s-core/issues/297)) ([14742f2](https://github.com/cdk8s-team/cdk8s-core/commit/14742f2fcd28a38e1505260533038b1d267d90a0)), closes [#296](https://github.com/cdk8s-team/cdk8s-core/issues/296)
+
+### [2.1.24](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.23...v2.1.24) (2022-01-28)
+
+### [2.1.23](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.22...v2.1.23) (2022-01-27)
+
+### [2.1.22](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.21...v2.1.22) (2022-01-26)
+
+### [2.1.21](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.20...v2.1.21) (2022-01-25)
+
+### [2.1.20](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.19...v2.1.20) (2022-01-24)
+
+### [2.1.19](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.18...v2.1.19) (2022-01-23)
+
+### [2.1.18](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.17...v2.1.18) (2022-01-22)
+
+### [2.1.17](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.16...v2.1.17) (2022-01-21)
+
+### [2.1.16](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.15...v2.1.16) (2022-01-20)
+
+### [2.1.15](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.14...v2.1.15) (2022-01-19)
+
+### [2.1.14](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.13...v2.1.14) (2022-01-18)
+
+### [2.1.13](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.12...v2.1.13) (2022-01-17)
+
+### [2.1.12](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.11...v2.1.12) (2022-01-16)
+
+### [2.1.11](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.10...v2.1.11) (2022-01-15)
+
+### [2.1.10](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.9...v2.1.10) (2022-01-14)
+
+### [2.1.9](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.8...v2.1.9) (2022-01-13)
+
+### [2.1.8](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.7...v2.1.8) (2022-01-12)
+
+### [2.1.6](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.5...v2.1.6) (2022-01-09)
+
+### [2.1.5](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.4...v2.1.5) (2022-01-08)
+
+### [2.1.4](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.3...v2.1.4) (2022-01-07)
+
+### [2.1.3](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.2...v2.1.3) (2022-01-06)
+
+### [2.1.2](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.1...v2.1.2) (2022-01-05)
+
+### [2.1.1](https://github.com/cdk8s-team/cdk8s-core/compare/v2.1.0...v2.1.1) (2022-01-04)
+
+## [2.1.0](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.21...v2.1.0) (2022-01-03)
+
+
+### Features
+
+* yaml output type FOLDER_PER_CHART_FILE_PER_RESOURCE ([#244](https://github.com/cdk8s-team/cdk8s-core/issues/244)) ([4a62805](https://github.com/cdk8s-team/cdk8s-core/commit/4a628053cd100e74c695870897746c1c56ee3c81))
+
+### [2.0.21](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.20...v2.0.21) (2022-01-03)
+
+### [2.0.20](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.19...v2.0.20) (2022-01-02)
+
+### [2.0.19](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.18...v2.0.19) (2022-01-02)
+
+### [2.0.18](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.17...v2.0.18) (2022-01-02)
+
+### [2.0.17](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.16...v2.0.17) (2022-01-01)
+
+### [2.0.16](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.15...v2.0.16) (2021-12-31)
+
+### [2.0.15](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.14...v2.0.15) (2021-12-30)
+
+### [2.0.14](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.13...v2.0.14) (2021-12-29)
+
+### [2.0.13](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.12...v2.0.13) (2021-12-29)
+
+### [2.0.12](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.11...v2.0.12) (2021-12-29)
+
+### [2.0.11](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.10...v2.0.11) (2021-12-28)
+
+### [2.0.10](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.9...v2.0.10) (2021-12-27)
+
+### [2.0.9](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.8...v2.0.9) (2021-12-26)
+
+### [2.0.8](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.7...v2.0.8) (2021-12-25)
+
+### [2.0.7](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.6...v2.0.7) (2021-12-24)
+
+### [2.0.6](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.5...v2.0.6) (2021-12-23)
+
+### [2.0.5](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.4...v2.0.5) (2021-12-22)
+
+### [2.0.4](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.3...v2.0.4) (2021-12-21)
+
+### [2.0.3](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.2...v2.0.3) (2021-12-20)
+
+### [2.0.2](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.1...v2.0.2) (2021-12-19)
+
+### [2.0.1](https://github.com/cdk8s-team/cdk8s-core/compare/v2.0.0...v2.0.1) (2021-12-18)
+
+## [2.0.0](https://github.com/cdk8s-team/cdk8s-core/compare/v1.3.2...v2.0.0) (2021-12-17)
+
+
+### ⚠ BREAKING CHANGES
+
+* migrate to constructs v10 (take 2) (#157)
+
+### Features
+
+* migrate to constructs v10 (take 2) ([#157](https://github.com/cdk8s-team/cdk8s-core/issues/157)) ([59f5ce2](https://github.com/cdk8s-team/cdk8s-core/commit/59f5ce2aa10d37c2ee8cc593cac56c2792c8c1da))
+
+### [1.3.2](https://github.com/cdk8s-team/cdk8s-core/compare/v1.3.1...v1.3.2) (2021-12-16)
+
+### [1.3.1](https://github.com/cdk8s-team/cdk8s-core/compare/v1.3.0...v1.3.1) (2021-12-16)
+
+## [1.3.0](https://github.com/cdk8s-team/cdk8s-core/compare/v1.2.11...v1.3.0) (2021-12-14)
+
+
+### Features
+
+* add constructs v10 compatibility ([#150](https://github.com/cdk8s-team/cdk8s-core/issues/150)) ([6adf8b3](https://github.com/cdk8s-team/cdk8s-core/commit/6adf8b39a4a37a3331d4c8e9ce8b283103822016))
+
+### [1.2.11](https://github.com/cdk8s-team/cdk8s-core/compare/v1.2.10...v1.2.11) (2021-12-13)
+
+### [1.2.10](https://github.com/cdk8s-team/cdk8s-core/compare/v1.2.9...v1.2.10) (2021-12-12)
+
+### [1.2.9](https://github.com/cdk8s-team/cdk8s-core/compare/v1.2.8...v1.2.9) (2021-12-11)
+
+### [1.2.8](https://github.com/cdk8s-team/cdk8s-core/compare/v1.2.7...v1.2.8) (2021-12-10)
+
+### [1.2.7](https://github.com/cdk8s-team/cdk8s-core/compare/v1.2.6...v1.2.7) (2021-12-09)
+
+### [1.2.6](https://github.com/cdk8s-team/cdk8s-core/compare/v1.2.5...v1.2.6) (2021-12-08)
+
+### [1.2.5](https://github.com/cdk8s-team/cdk8s-core/compare/v1.2.4...v1.2.5) (2021-12-07)
+
+### [1.2.4](https://github.com/cdk8s-team/cdk8s-core/compare/v1.2.3...v1.2.4) (2021-12-06)
+
+### [1.2.3](https://github.com/cdk8s-team/cdk8s-core/compare/v1.2.2...v1.2.3) (2021-12-05)
+
+### [1.2.2](https://github.com/cdk8s-team/cdk8s-core/compare/v1.2.1...v1.2.2) (2021-12-02)
+
+### [1.2.1](https://github.com/cdk8s-team/cdk8s-core/compare/v1.2.0...v1.2.1) (2021-12-01)
+
+## [1.2.0](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.48...v1.2.0) (2021-11-30)
+
+
+### Features
+
+* **app:** introduce `synthYaml()` ([#135](https://github.com/cdk8s-team/cdk8s-core/issues/135)) ([89b6920](https://github.com/cdk8s-team/cdk8s-core/commit/89b6920019771593005a027f5b9bdd03eab53219)), closes [#134](https://github.com/cdk8s-team/cdk8s-core/issues/134)
+
+### [1.1.48](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.47...v1.1.48) (2021-11-30)
+
+### [1.1.47](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.46...v1.1.47) (2021-11-29)
+
+### [1.1.46](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.45...v1.1.46) (2021-11-28)
+
+### [1.1.45](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.44...v1.1.45) (2021-11-27)
+
+### [1.1.44](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.43...v1.1.44) (2021-11-26)
+
+### [1.1.43](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.42...v1.1.43) (2021-11-25)
+
+### [1.1.42](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.41...v1.1.42) (2021-11-24)
+
+### [1.1.41](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.40...v1.1.41) (2021-11-23)
+
+### [1.1.40](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.39...v1.1.40) (2021-11-22)
+
+### [1.1.39](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.38...v1.1.39) (2021-11-20)
+
+### [1.1.38](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.37...v1.1.38) (2021-11-19)
+
+### [1.1.37](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.36...v1.1.37) (2021-11-18)
+
+### [1.1.36](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.35...v1.1.36) (2021-11-17)
+
+### [1.1.35](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.34...v1.1.35) (2021-11-16)
+
+### [1.1.34](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.33...v1.1.34) (2021-11-15)
+
+### [1.1.33](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.32...v1.1.33) (2021-11-14)
+
+### [1.1.32](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.31...v1.1.32) (2021-11-13)
+
+### [1.1.31](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.30...v1.1.31) (2021-11-12)
+
+### [1.1.30](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.29...v1.1.30) (2021-11-11)
+
+### [1.1.29](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.28...v1.1.29) (2021-11-10)
+
+### [1.1.28](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.27...v1.1.28) (2021-11-09)
+
+### [1.1.27](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.26...v1.1.27) (2021-11-08)
+
+### [1.1.26](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.25...v1.1.26) (2021-11-06)
+
+### [1.1.25](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.24...v1.1.25) (2021-11-06)
+
+### [1.1.24](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.23...v1.1.24) (2021-11-05)
+
+### [1.1.23](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.22...v1.1.23) (2021-11-04)
+
+### [1.1.22](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.21...v1.1.22) (2021-11-03)
+
+### [1.1.21](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.20...v1.1.21) (2021-11-02)
+
+### [1.1.20](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.19...v1.1.20) (2021-11-01)
+
+### [1.1.19](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.18...v1.1.19) (2021-10-31)
+
+### [1.1.18](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.17...v1.1.18) (2021-10-30)
+
+### [1.1.17](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.16...v1.1.17) (2021-10-29)
+
+### [1.1.16](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.15...v1.1.16) (2021-10-28)
+
+### [1.1.15](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.14...v1.1.15) (2021-10-27)
+
+### [1.1.14](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.13...v1.1.14) (2021-10-26)
+
+### [1.1.13](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.12...v1.1.13) (2021-10-25)
+
+### [1.1.12](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.11...v1.1.12) (2021-10-24)
+
+### [1.1.11](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.10...v1.1.11) (2021-10-23)
+
+### [1.1.10](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.9...v1.1.10) (2021-10-22)
+
+### [1.1.9](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.8...v1.1.9) (2021-10-21)
+
+### [1.1.8](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.7...v1.1.8) (2021-10-20)
+
+### [1.1.7](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.6...v1.1.7) (2021-10-19)
+
+### [1.1.6](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.5...v1.1.6) (2021-10-18)
+
+### [1.1.5](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.4...v1.1.5) (2021-10-17)
+
+### [1.1.4](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.3...v1.1.4) (2021-10-16)
+
+### [1.1.3](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.2...v1.1.3) (2021-10-15)
+
+### [1.1.2](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.1...v1.1.2) (2021-10-14)
+
+### [1.1.1](https://github.com/cdk8s-team/cdk8s-core/compare/v1.1.0...v1.1.1) (2021-10-13)
+
+## [1.1.0](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0...v1.1.0) (2021-10-12)
+
+
+### Features
+
+* add finalizer and owner reference metadata options ([#62](https://github.com/cdk8s-team/cdk8s-core/issues/62)) ([446df9c](https://github.com/cdk8s-team/cdk8s-core/commit/446df9c891f0cf82fcd903d3a6e826808f318696)), closes [#61](https://github.com/cdk8s-team/cdk8s-core/issues/61)
+
+## [1.0.0](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.63...v1.0.0) (2021-10-12)
+
+
+### Features
+
+* 1.0 🚀 ([#80](https://github.com/cdk8s-team/cdk8s-core/issues/80)) ([b7e13a0](https://github.com/cdk8s-team/cdk8s-core/commit/b7e13a0f305df3f970f76a49d743b395fbd35330))
+
+## [1.0.0-beta.63](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.62...v1.0.0-beta.63) (2021-10-11)
+
+## [1.0.0-beta.62](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.61...v1.0.0-beta.62) (2021-10-10)
+
+## [1.0.0-beta.61](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.60...v1.0.0-beta.61) (2021-10-09)
+
+## [1.0.0-beta.60](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.59...v1.0.0-beta.60) (2021-10-08)
+
+## [1.0.0-beta.59](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.58...v1.0.0-beta.59) (2021-10-07)
+
+## [1.0.0-beta.58](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.57...v1.0.0-beta.58) (2021-10-06)
+
+## [1.0.0-beta.57](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.56...v1.0.0-beta.57) (2021-10-05)
+
+## [1.0.0-beta.56](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.55...v1.0.0-beta.56) (2021-10-04)
+
+## [1.0.0-beta.55](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.54...v1.0.0-beta.55) (2021-10-03)
+
+## [1.0.0-beta.54](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.53...v1.0.0-beta.54) (2021-10-03)
+
+## [1.0.0-beta.53](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.52...v1.0.0-beta.53) (2021-09-26)
+
+## [1.0.0-beta.52](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.51...v1.0.0-beta.52) (2021-09-25)
+
+## [1.0.0-beta.51](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.50...v1.0.0-beta.51) (2021-09-24)
+
+## [1.0.0-beta.50](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.49...v1.0.0-beta.50) (2021-09-23)
+
+## [1.0.0-beta.49](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.48...v1.0.0-beta.49) (2021-09-22)
+
+## [1.0.0-beta.48](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.47...v1.0.0-beta.48) (2021-09-21)
+
+## [1.0.0-beta.47](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.46...v1.0.0-beta.47) (2021-09-20)
+
+## [1.0.0-beta.46](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.45...v1.0.0-beta.46) (2021-09-11)
+
+## [1.0.0-beta.45](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.44...v1.0.0-beta.45) (2021-09-10)
+
+## [1.0.0-beta.44](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.43...v1.0.0-beta.44) (2021-09-10)
+
+## [1.0.0-beta.43](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.42...v1.0.0-beta.43) (2021-09-09)
+
+## [1.0.0-beta.42](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.41...v1.0.0-beta.42) (2021-09-09)
+
+## [1.0.0-beta.41](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.40...v1.0.0-beta.41) (2021-09-08)
+
+## [1.0.0-beta.40](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.39...v1.0.0-beta.40) (2021-09-07)
+
+## [1.0.0-beta.39](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.38...v1.0.0-beta.39) (2021-09-03)
+
+## [1.0.0-beta.33](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.32...v1.0.0-beta.33) (2021-09-01)
+
+## [1.0.0-beta.32](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.31...v1.0.0-beta.32) (2021-08-28)
+
+## [1.0.0-beta.31](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.30...v1.0.0-beta.31) (2021-08-24)
+
+
+### Features
+
+* upgrade dependencies and API docs ([#46](https://github.com/cdk8s-team/cdk8s-core/issues/46)) ([ca07816](https://github.com/cdk8s-team/cdk8s-core/commit/ca0781663974625839bd7ae426be8887af831a6e))
+
+## [1.0.0-beta.30](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.29...v1.0.0-beta.30) (2021-08-15)
+
+## [1.0.0-beta.29](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.28...v1.0.0-beta.29) (2021-08-12)
+
+## [1.0.0-beta.28](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.27...v1.0.0-beta.28) (2021-08-09)
+
+
+### Features
+
+* Allow configuration of how YAML output is divided into files ([#24](https://github.com/cdk8s-team/cdk8s-core/issues/24)) ([474e373](https://github.com/cdk8s-team/cdk8s-core/commit/474e373c1b86a57a3568cca0f9629e038266f2d5)), closes [#37](https://github.com/cdk8s-team/cdk8s-core/issues/37)
+
+## [1.0.0-beta.27](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.26...v1.0.0-beta.27) (2021-07-29)
+
+
+### Bug Fixes
+
+* duplicated objects when charts are nested ([#40](https://github.com/cdk8s-team/cdk8s-core/issues/40)) ([f55ab10](https://github.com/cdk8s-team/cdk8s-core/commit/f55ab10b6b8ab192429a123e059ef875d92fe62c)), closes [#31](https://github.com/cdk8s-team/cdk8s-core/issues/31)
+
+## [1.0.0-beta.26](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.25...v1.0.0-beta.26) (2021-06-22)
+
+## [1.0.0-beta.25](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.24...v1.0.0-beta.25) (2021-06-20)
+
+## [1.0.0-beta.24](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.23...v1.0.0-beta.24) (2021-06-14)
+
+## [1.0.0-beta.23](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.22...v1.0.0-beta.23) (2021-06-13)
+
+## [1.0.0-beta.22](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.21...v1.0.0-beta.22) (2021-06-13)
+
+## [1.0.0-beta.21](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.20...v1.0.0-beta.21) (2021-06-07)
+
+## [1.0.0-beta.20](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.19...v1.0.0-beta.20) (2021-06-07)
+
+## [1.0.0-beta.19](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.18...v1.0.0-beta.19) (2021-06-06)
+
+## [1.0.0-beta.18](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.17...v1.0.0-beta.18) (2021-06-01)
+
+## [1.0.0-beta.17](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.16...v1.0.0-beta.17) (2021-06-01)
+
+## [1.0.0-beta.16](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.15...v1.0.0-beta.16) (2021-06-01)
+
+## [1.0.0-beta.15](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.14...v1.0.0-beta.15) (2021-06-01)
+
+## [1.0.0-beta.14](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.13...v1.0.0-beta.14) (2021-05-31)
+
+## [1.0.0-beta.13](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.12...v1.0.0-beta.13) (2021-05-31)
+
+## [1.0.0-beta.12](https://github.com/cdk8s-team/cdk8s-core/compare/v1.0.0-beta.11...v1.0.0-beta.12) (2021-05-31)
+
+## [1.0.0-beta.11](https://github.com/cdk8s-team/cdk8s-core/compare/2616372a202c552e0fdd1be73eff2dbe5175704b...v1.0.0-beta.11) (2021-05-26)
+
+
+### ⚠ BREAKING CHANGES
+
+* **lib:** the deprecated API `Duration.toISOString()` has been removed. Use `Duration.toIsoString()` instead.
+* **lib:** CAUTION! Auto-generated resource names will change with this release. Resource names in manifests synthesized by a previous version of the CDK8s will be invalidated. Deploying new manifests will cause **resources to be replaced**. Temporarily, you can opt to use the legacy hashing mechanism by setting the environment variable `CDK8S_LEGACY_HASH=1`.
+* **lib:** `Names.toDnsLabel()` now accepts a construct scope instead of a string path, and a set of options instead of `maxLen`.
+* **lib:** `Names.toLabelValue()` now accepts a construct scope instead of a string path, and a set of options instead of `maxLen`.
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **plus-17:** All L2 resource names will undergo a name change (e.g `test-chart-config-configmap-233db8e7` -> `test-chart-config-c3f7d3c0`)
+
+Resolves https://github.com/awslabs/cdk8s/issues/373
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* Construct input types generated by `cdk8s import` are now called `XxxProps` instead of `XxxOptions` to conform with the CDK ecosystem.
+* **core:** `ApiObjectOptions` is now called `ApiObjectProps`
+* **core:** `AppOptions` is now called `AppProps`
+* **core:** `ChartOptions` is now called `ChartProps`
+* **core:** `HelmOptions` is now called `HelmProps`
+* **core:** `IncludeOptions` is now called `IncludeProps`
+* **cli:** when importing k8s api objects using `cdk8s import`, non-stable APIs will be have an API level postfix. For example, k8s@1.18 will have an `IngressV1Beta1` API object.
+* **cli:** The `--include` CLI option has been removed since all API objects are always imported.
+* **cli:** When using the CLI to import the core Kubernetes API objects, the imported classes will now have a `Kube` prefix in order to make it easier to differentiate them from the classes offered by the high-level APIs in CDK8s+ (e.g. `k8s.Deployment` is now `k8s.KubeDeployment`). You can disable through the `--no-class-prefix` option: `cdk8s import --no-class-prefix k8s`.
+* **plus:** Containers now need to be inputed as interfaces rather than classes. Instead of passing `new kplus.Container(props)`, simply pass in `props`.
+
+Resolves https://github.com/awslabs/cdk8s/issues/365
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **lib:** `EnvValue.fromSecret(secret, key)` has been removed in favor of `EnvValue.fromSecretValue({ secret, key })`.
+* **plus:** `spec` was removed from all cdk8s+ constructs and that now have a flat structure. See [Example](https://github.com/awslabs/cdk8s/tree/master/packages/cdk8s-plus#at-a-glance) for new usage.
+
+* **plus**: Construct id's for deployment will change due to a latent bug that appended the word `pod` to them.
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **plus:** `deployment.expose()` now takes `port` as a positional argument (before: `deployment.expose({ port })`, now: `deployment.expose(port)`).
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **lib:** auto-generated resource names that included duplicate hyphens will change will be replaced when applied.
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **lib:** cdk8s-plus's value of a label `cdk8s.deployment` of Pods are changed
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **lib:** resource names will now be rendered differently, omitting adjacent duplicate components.
+
+Signed-off-by: campionfellin <campionfellin@gmail.com>
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **lib:** `cdk8s` discontinues support for the `onPrepare` and `onSynthesis` construct hooks. These methods will eventually be removed from the `constructs` programming model.
+* **cli:** enum string values are now proper enums instead of just `string`s.
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **cli:** the generated module names of imported CRDs now include the resource's group and not just its kind in order to ensure uniqueness. For example, when importing the Jenkins CRD, instead of 'imports/jenkins.ts`, we now have `imports/jenkins.io/jenkins.ts`.
+- **cli**: class names are now normalized to `PascalCase`.
+* please upgrade your dependency requirement for "constructs" to ^2.0.0
+* **cli:** `cdk8s gen` is now `cdk8s import k8s` and output goes to `imports/k8s.ts` instead of `.gen/index.ts`.
+* **cli:** `cdk8s import` now generates a single file with all types, which means you will have to modify TypeScript code to `import { Deployment, Pod, ... } from './imports/k8s'` instead of importing multiple files.
+
+### Features
+
+* add contributor instructions about using jsii docker image ([#397](https://github.com/cdk8s-team/cdk8s-core/issues/397)) ([bb0a5cc](https://github.com/cdk8s-team/cdk8s-core/commit/bb0a5cc0762e753f1f18093b3cd15cbb83bd7c5e))
+* allow arbitrary construct names ([#64](https://github.com/cdk8s-team/cdk8s-core/issues/64)) ([1309960](https://github.com/cdk8s-team/cdk8s-core/commit/1309960e62d13b00dc964f6c88e15d74390e09a2)), closes [#48](https://github.com/cdk8s-team/cdk8s-core/issues/48)
+* cdk8s website ([#89](https://github.com/cdk8s-team/cdk8s-core/issues/89)) ([430d9b7](https://github.com/cdk8s-team/cdk8s-core/commit/430d9b7e6b99dd54e6fe611fb22e1dcafb18cc13))
+* **cdk8s:** k8s-compatible object names from construct path ([2f3df34](https://github.com/cdk8s-team/cdk8s-core/commit/2f3df34bc3343ddd85472f77945f093b69ad4076))
+* **cdk8s:** the App root construct ([#15](https://github.com/cdk8s-team/cdk8s-core/issues/15)) ([c595240](https://github.com/cdk8s-team/cdk8s-core/commit/c595240ed934c300ad5f9db209692d2113b3d113))
+* chart-level labels ([#355](https://github.com/cdk8s-team/cdk8s-core/issues/355)) ([c545c1e](https://github.com/cdk8s-team/cdk8s-core/commit/c545c1efec86d3af5852101d01f4fbad2e000ac6))
+* chart.generateObjectName ([03a1d26](https://github.com/cdk8s-team/cdk8s-core/commit/03a1d2668a7c4fef9dac5db81b6496eff2208eab))
+* Chart.of(node) ([d6a9dc0](https://github.com/cdk8s-team/cdk8s-core/commit/d6a9dc0cb87d11fd603f330059cc1ab326c44a71))
+* chart.toJson() and apiObject.toJson() ([#63](https://github.com/cdk8s-team/cdk8s-core/issues/63)) ([80e8402](https://github.com/cdk8s-team/cdk8s-core/commit/80e8402790c4112e64bda2dd9a42fa897ee4ab8b)), closes [#48](https://github.com/cdk8s-team/cdk8s-core/issues/48)
+* **cli:** "cdk8s gen" is now "cdk8s import k8s" ([#43](https://github.com/cdk8s-team/cdk8s-core/issues/43)) ([fb9e0b5](https://github.com/cdk8s-team/cdk8s-core/commit/fb9e0b5396a019bd979cc6ad0f646d76c5b85bc6)), closes [#31](https://github.com/cdk8s-team/cdk8s-core/issues/31) [#40](https://github.com/cdk8s-team/cdk8s-core/issues/40)
+* **cli:** cdk8s import crd.yaml ([#70](https://github.com/cdk8s-team/cdk8s-core/issues/70)) ([5d1c278](https://github.com/cdk8s-team/cdk8s-core/commit/5d1c278f391f2561c8999efcd2015f2de9e26b72)), closes [#27](https://github.com/cdk8s-team/cdk8s-core/issues/27)
+* **cli:** cdk8s init template for java ([#245](https://github.com/cdk8s-team/cdk8s-core/issues/245)) ([2bec62a](https://github.com/cdk8s-team/cdk8s-core/commit/2bec62afac55fc8fe0c34ed6cfbb508977c43815))
+* **cli:** cdk8s synth ([#44](https://github.com/cdk8s-team/cdk8s-core/issues/44)) ([d457ea9](https://github.com/cdk8s-team/cdk8s-core/commit/d457ea9184e45c5d94b93ac17e3deecdd0b8c657)), closes [#41](https://github.com/cdk8s-team/cdk8s-core/issues/41)
+* **cli:** cdk8s.yaml ([#52](https://github.com/cdk8s-team/cdk8s-core/issues/52)) ([e6834d3](https://github.com/cdk8s-team/cdk8s-core/commit/e6834d3ae03810d1402c34a123adb8a1376808b7)), closes [#42](https://github.com/cdk8s-team/cdk8s-core/issues/42)
+* **cli:** class prefix for imported constructs ([#370](https://github.com/cdk8s-team/cdk8s-core/issues/370)) ([0b18df3](https://github.com/cdk8s-team/cdk8s-core/commit/0b18df37a42d1c2f29719089cf7996efdbab8cb3)), closes [#140](https://github.com/cdk8s-team/cdk8s-core/issues/140)
+* **cli:** enable using imported resources as raw manifests ([#447](https://github.com/cdk8s-team/cdk8s-core/issues/447)) ([aa2422e](https://github.com/cdk8s-team/cdk8s-core/commit/aa2422e1844d4684b0c61f871c9cbc9f34c08183))
+* **cli:** ignore hidden files in "cdk8s init" ([#99](https://github.com/cdk8s-team/cdk8s-core/issues/99)) ([5681e14](https://github.com/cdk8s-team/cdk8s-core/commit/5681e148ce7621562d27ca32843183337554943c))
+* **cli:** import - support enum string fields ([#210](https://github.com/cdk8s-team/cdk8s-core/issues/210)) ([8b8ad44](https://github.com/cdk8s-team/cdk8s-core/commit/8b8ad44bba1f0ebced6d41af52d079b1a2ec54b2)), closes [#196](https://github.com/cdk8s-team/cdk8s-core/issues/196)
+* **cli:** import a single module per api group ([#402](https://github.com/cdk8s-team/cdk8s-core/issues/402)) ([ac295fe](https://github.com/cdk8s-team/cdk8s-core/commit/ac295fe78544c4b06f732fe945dfa6423eea5c83)), closes [#378](https://github.com/cdk8s-team/cdk8s-core/issues/378) [#401](https://github.com/cdk8s-team/cdk8s-core/issues/401)
+* **cli:** import constructs for all API levels ([#379](https://github.com/cdk8s-team/cdk8s-core/issues/379)) ([b0d7621](https://github.com/cdk8s-team/cdk8s-core/commit/b0d76210fe944b03f8197b821da134120015e139)), closes [#380](https://github.com/cdk8s-team/cdk8s-core/issues/380)
+* **cli:** import CRDs from a running cluster ([#207](https://github.com/cdk8s-team/cdk8s-core/issues/207)) ([5153422](https://github.com/cdk8s-team/cdk8s-core/commit/5153422432d78aa97b928f507be27048e1868c7a)), closes [#197](https://github.com/cdk8s-team/cdk8s-core/issues/197)
+* **cli:** import from crds.dev ([#378](https://github.com/cdk8s-team/cdk8s-core/issues/378)) ([c62d0a4](https://github.com/cdk8s-team/cdk8s-core/commit/c62d0a4c86c6256d93cc8b717b081fd4a16de0be)), closes [#377](https://github.com/cdk8s-team/cdk8s-core/issues/377)
+* **cli:** import only one class for every api object ([#39](https://github.com/cdk8s-team/cdk8s-core/issues/39)) ([2db4cfb](https://github.com/cdk8s-team/cdk8s-core/commit/2db4cfbb20e7b6d8b09e8b8c9e6d096f0ea9fefe))
+* **cli:** java import support  ([#226](https://github.com/cdk8s-team/cdk8s-core/issues/226)) ([9619a73](https://github.com/cdk8s-team/cdk8s-core/commit/9619a730766a109e429007c459f77541ebb97399))
+* **cli:** jest tests in typescript-app template ([b6aed5a](https://github.com/cdk8s-team/cdk8s-core/commit/b6aed5ad9252c18f6f86d94caa472895c1c6a529))
+* **cli:** new version notifications ([#454](https://github.com/cdk8s-team/cdk8s-core/issues/454)) ([065756e](https://github.com/cdk8s-team/cdk8s-core/commit/065756ef89afa938cc120f3af83b23851e06098d)), closes [#452](https://github.com/cdk8s-team/cdk8s-core/issues/452)
+* **cli:** project templates with "cdk8s init" ([#10](https://github.com/cdk8s-team/cdk8s-core/issues/10)) ([4aa59d9](https://github.com/cdk8s-team/cdk8s-core/commit/4aa59d9486d475b008244a90b6a1ee23772b5700))
+* **cli:** python project template ([9be957f](https://github.com/cdk8s-team/cdk8s-core/commit/9be957f4a34f8ad94afd77541a29dfdf423cb608))
+* **cli:** python project template ([#36](https://github.com/cdk8s-team/cdk8s-core/issues/36)) ([30f3bb7](https://github.com/cdk8s-team/cdk8s-core/commit/30f3bb7d787f0d1b16b90c8ddafc4dcc451c4e4b))
+* **cli:** python support for "import" ([#47](https://github.com/cdk8s-team/cdk8s-core/issues/47)) ([3b93d64](https://github.com/cdk8s-team/cdk8s-core/commit/3b93d6465c2748693ce220c307c1b94b1cdaa11f))
+* **cli:** remove the cookiecutter prerequisite ([#13](https://github.com/cdk8s-team/cdk8s-core/issues/13)) ([10ab259](https://github.com/cdk8s-team/cdk8s-core/commit/10ab2591828b790a6bbcdb306d302d5f8a30d30e))
+* **cli:** stdout option for cdk8s synth ([#361](https://github.com/cdk8s-team/cdk8s-core/issues/361)) ([bbf116b](https://github.com/cdk8s-team/cdk8s-core/commit/bbf116b93d9a14c24094aa51ec3a383489341190))
+* **cli:** support CRDs with apiVersion "apiextensions.k8s.io/v1" ([#142](https://github.com/cdk8s-team/cdk8s-core/issues/142)) ([f5111b0](https://github.com/cdk8s-team/cdk8s-core/commit/f5111b07eefbc58a4ae23b498e6b41f48a0b82ac))
+* **cli:** support import module name overriding in python ([#107](https://github.com/cdk8s-team/cdk8s-core/issues/107)) ([327ba47](https://github.com/cdk8s-team/cdk8s-core/commit/327ba47524b7dfdb05096bb9a78c9d504db4a02c))
+* **cli:** typescript - yarn run upgrade & upgrade:next ([735e840](https://github.com/cdk8s-team/cdk8s-core/commit/735e840f0ef440e715d34923aed184e58a9f243c))
+* **cli:** typescript project - "yarn build" now includes "synth" ([7b15e3a](https://github.com/cdk8s-team/cdk8s-core/commit/7b15e3a4f47e4d17b417012a82b335690be8cc52))
+* cookiecutter template for typescript app projects ([#9](https://github.com/cdk8s-team/cdk8s-core/issues/9)) ([55087e2](https://github.com/cdk8s-team/cdk8s-core/commit/55087e2be37de680b8dea25a806f013e17f6351a))
+* default chart namespaces ([#68](https://github.com/cdk8s-team/cdk8s-core/issues/68)) ([36b9ff1](https://github.com/cdk8s-team/cdk8s-core/commit/36b9ff1b32699da894eae085c809c2399ac9b837))
+* **docs:** add python and pipenv prerequisites ([db23fa1](https://github.com/cdk8s-team/cdk8s-core/commit/db23fa168ed6262d199383a651769fc2fae14a11)), closes [#166](https://github.com/cdk8s-team/cdk8s-core/issues/166)
+* **docs:** getting started in python ([#60](https://github.com/cdk8s-team/cdk8s-core/issues/60)) ([27d3bac](https://github.com/cdk8s-team/cdk8s-core/commit/27d3bac4579ea8cdf0b6c692e05ab0ac47e17590))
+* documentation website ([#367](https://github.com/cdk8s-team/cdk8s-core/issues/367)) ([505f946](https://github.com/cdk8s-team/cdk8s-core/commit/505f9460e53a0cf3a0249b762431addda999ec4a)), closes [#366](https://github.com/cdk8s-team/cdk8s-core/issues/366)
+* escape hatches ([#372](https://github.com/cdk8s-team/cdk8s-core/issues/372)) ([12b0f01](https://github.com/cdk8s-team/cdk8s-core/commit/12b0f01c5c1ef4c621f5b501d39911a207251ca1)), closes [#144](https://github.com/cdk8s-team/cdk8s-core/issues/144)
+* **example:** python hello example ([#101](https://github.com/cdk8s-team/cdk8s-core/issues/101)) ([e792d2b](https://github.com/cdk8s-team/cdk8s-core/commit/e792d2bebb5101daecc53c4aaed9500c3ef27617))
+* **examples:** central readme for all examples ([#176](https://github.com/cdk8s-team/cdk8s-core/issues/176)) ([9cab302](https://github.com/cdk8s-team/cdk8s-core/commit/9cab302939c3d8ce3104e30d2bd1ad22b87bcbf8)), closes [#174](https://github.com/cdk8s-team/cdk8s-core/issues/174)
+* **examples:** Elasticsearch query using CDK8s+ and CRD ([#281](https://github.com/cdk8s-team/cdk8s-core/issues/281)) ([3be1a96](https://github.com/cdk8s-team/cdk8s-core/commit/3be1a96b1801f2e23673b454e0a0b59cf7f1b6e5))
+* **examples:** reorganize examples by language ([#138](https://github.com/cdk8s-team/cdk8s-core/issues/138)) ([85cf631](https://github.com/cdk8s-team/cdk8s-core/commit/85cf6313c20771b718c19ee6085afc23cd787311))
+* **examples:** updates to hello-world example and directory reorganization ([#33](https://github.com/cdk8s-team/cdk8s-core/issues/33)) ([1c8f694](https://github.com/cdk8s-team/cdk8s-core/commit/1c8f694b51fac662477175c2e8f12b38b810d2bf))
+* experimental golang bindings ([#523](https://github.com/cdk8s-team/cdk8s-core/issues/523)) ([6737351](https://github.com/cdk8s-team/cdk8s-core/commit/6737351ee3c3d119e0a2969e90f911b9e45c1a11))
+* getting started documentation ([2616372](https://github.com/cdk8s-team/cdk8s-core/commit/2616372a202c552e0fdd1be73eff2dbe5175704b))
+* ImagePullPolicy support for cdk8s-plus Container ([#313](https://github.com/cdk8s-team/cdk8s-core/issues/313)) ([8307757](https://github.com/cdk8s-team/cdk8s-core/commit/8307757deb9b70db4fda716d4a4afb7cef522dc9))
+* Introducing "cdk8s+": high-level APIs for Kubernetes ([#239](https://github.com/cdk8s-team/cdk8s-core/issues/239)) ([1b991f6](https://github.com/cdk8s-team/cdk8s-core/commit/1b991f691bd214e9aaac66e90e3b065d0c31b9aa))
+* **lib:** allow hash to be optionally included in Names functions. ([#396](https://github.com/cdk8s-team/cdk8s-core/issues/396)) ([2c86526](https://github.com/cdk8s-team/cdk8s-core/commit/2c86526e6434b7317c338b3446613b8ff7650e5a))
+* **lib:** dependencies and ordering of charts and objects ([#223](https://github.com/cdk8s-team/cdk8s-core/issues/223)) ([701579e](https://github.com/cdk8s-team/cdk8s-core/commit/701579e46a1f5891a1233c2e44e06a528f5a183e)), closes [#111](https://github.com/cdk8s-team/cdk8s-core/issues/111)
+* **lib:** Expose DependecyGraph for upstream use ([#329](https://github.com/cdk8s-team/cdk8s-core/issues/329)) ([ee88402](https://github.com/cdk8s-team/cdk8s-core/commit/ee884023a313fae44e69124da9e37a9e52611845)), closes [#328](https://github.com/cdk8s-team/cdk8s-core/issues/328)
+* **lib:** flag to disable dictionary sort ([#534](https://github.com/cdk8s-team/cdk8s-core/issues/534)) ([a4eca40](https://github.com/cdk8s-team/cdk8s-core/commit/a4eca40f72d654ea0355ec513073b05c7dbffe9e)), closes [#525](https://github.com/cdk8s-team/cdk8s-core/issues/525)
+* **lib:** helm construct ([#346](https://github.com/cdk8s-team/cdk8s-core/issues/346)) ([6ee449f](https://github.com/cdk8s-team/cdk8s-core/commit/6ee449fc1b82e2c59ec24d327044f828665df8b5)), closes [#65](https://github.com/cdk8s-team/cdk8s-core/issues/65)
+* **lib:** introduce "include" ([#202](https://github.com/cdk8s-team/cdk8s-core/issues/202)) ([75d13e8](https://github.com/cdk8s-team/cdk8s-core/commit/75d13e8b06351b66bd5d495f6ac6a3575fac6421)), closes [#199](https://github.com/cdk8s-team/cdk8s-core/issues/199)
+* **lib:** omit duplicate components in generated names ([#258](https://github.com/cdk8s-team/cdk8s-core/issues/258)) ([473b5ef](https://github.com/cdk8s-team/cdk8s-core/commit/473b5ef7f442b932e9c4c4356945b91e8e1bc4e4))
+* **lib:** SecretValue ([#351](https://github.com/cdk8s-team/cdk8s-core/issues/351)) ([dd7cf58](https://github.com/cdk8s-team/cdk8s-core/commit/dd7cf5857b82da75b88f6786933070c570e5df23))
+* **lib:** yaml utility functions ([#198](https://github.com/cdk8s-team/cdk8s-core/issues/198)) ([9e0f030](https://github.com/cdk8s-team/cdk8s-core/commit/9e0f030ecdb249d9095d0d774b33919a17cc48f7))
+* migrate to cdk.dev slack workspace ([#336](https://github.com/cdk8s-team/cdk8s-core/issues/336)) ([b203e5a](https://github.com/cdk8s-team/cdk8s-core/commit/b203e5a897e297227c33442031ce3b0dcfefa486))
+* new website ([#143](https://github.com/cdk8s-team/cdk8s-core/issues/143)) ([fcc59b0](https://github.com/cdk8s-team/cdk8s-core/commit/fcc59b062824aad31dea209fa9df1088425c240b))
+* only publish doc site on release commits ([#507](https://github.com/cdk8s-team/cdk8s-core/issues/507)) ([5acc54b](https://github.com/cdk8s-team/cdk8s-core/commit/5acc54b004951e60334abc369ec85a537cc2a973))
+* peer-depend on "constructs" instead of "@aws-cdk/core" ([#66](https://github.com/cdk8s-team/cdk8s-core/issues/66)) ([c336c95](https://github.com/cdk8s-team/cdk8s-core/commit/c336c95f4e4355f94abe66d2839ccbb26d4f15b8))
+* **plus-17:** add StatefulSet construct ([#400](https://github.com/cdk8s-team/cdk8s-core/issues/400)) ([98aad99](https://github.com/cdk8s-team/cdk8s-core/commit/98aad99a0a325b706c8f1c4e5f2ac1af77795400))
+* **plus-17:** Add type option for secrets in kplus. ([#425](https://github.com/cdk8s-team/cdk8s-core/issues/425)) ([28d660f](https://github.com/cdk8s-team/cdk8s-core/commit/28d660f6d252de26268d3eb72060580894de3e21))
+* **plus-17:** additional options for the Job construct. ([#398](https://github.com/cdk8s-team/cdk8s-core/issues/398)) ([17e8801](https://github.com/cdk8s-team/cdk8s-core/commit/17e8801bc748e3ff0e999b994645058cc17637ce))
+* **plus-17:** restrict CIDR IP addresses for a LoadBalancer ([#446](https://github.com/cdk8s-team/cdk8s-core/issues/446)) ([cf96ae2](https://github.com/cdk8s-team/cdk8s-core/commit/cf96ae2319e821307e23d6343883b531294e6359)), closes [#435](https://github.com/cdk8s-team/cdk8s-core/issues/435)
+* **plus:** add liveness and startup probes to Container ([#358](https://github.com/cdk8s-team/cdk8s-core/issues/358)) ([f3f9a6a](https://github.com/cdk8s-team/cdk8s-core/commit/f3f9a6a7474e60ff90376a4d74be55d08014b2d3))
+* **plus:** Container is now inputed as an interface instead of class ([#376](https://github.com/cdk8s-team/cdk8s-core/issues/376)) ([33bf97a](https://github.com/cdk8s-team/cdk8s-core/commit/33bf97a9a6f4bca5c259964d833955639835f12c))
+* **plus:** expose service options in `expose()` ([#357](https://github.com/cdk8s-team/cdk8s-core/issues/357)) ([7137698](https://github.com/cdk8s-team/cdk8s-core/commit/713769883c9b4fe0ec443d0e776155d720b65cb6))
+* **plus:** Ingress ([#340](https://github.com/cdk8s-team/cdk8s-core/issues/340)) ([14ac668](https://github.com/cdk8s-team/cdk8s-core/commit/14ac668f5f88445f14864ac3d271f8a9afbd40c7)), closes [#125](https://github.com/cdk8s-team/cdk8s-core/issues/125)
+* **plus:** readiness probes ([#353](https://github.com/cdk8s-team/cdk8s-core/issues/353)) ([a57e466](https://github.com/cdk8s-team/cdk8s-core/commit/a57e466d67b561bec95c7be26eb7a36625ebb744))
+* **plus:** service.addDeployment() ([#342](https://github.com/cdk8s-team/cdk8s-core/issues/342)) ([5413b3b](https://github.com/cdk8s-team/cdk8s-core/commit/5413b3bf6ca13f9839407d561b622e64a4de62e4))
+* **podinfo:** allow containers to bind to deployment ([45237c0](https://github.com/cdk8s-team/cdk8s-core/commit/45237c0aa630a7c0992abee9303dc86b73aba4f5))
+* **readme:** add link to "awesome cdk8s" ([0889a6e](https://github.com/cdk8s-team/cdk8s-core/commit/0889a6e5d738d928219b24c523b8bfdcec73bc43))
+* sort keys of ApiObject manifests ([#67](https://github.com/cdk8s-team/cdk8s-core/issues/67)) ([1fe89bd](https://github.com/cdk8s-team/cdk8s-core/commit/1fe89bd7355d48c99c35be7d4429b1095529dc7f)), closes [#17](https://github.com/cdk8s-team/cdk8s-core/issues/17)
+* surface cdk8s in awscdk.io ([45e188e](https://github.com/cdk8s-team/cdk8s-core/commit/45e188e08a607a0fbc8b5003ce9ab84789f1322e))
+* switch to 1.0.0-beta version line ([#384](https://github.com/cdk8s-team/cdk8s-core/issues/384)) ([ffce8c6](https://github.com/cdk8s-team/cdk8s-core/commit/ffce8c696ce502ec4a14f65b715474faa7f74c7b))
+* **website:** add reference docs links ([2034ec0](https://github.com/cdk8s-team/cdk8s-core/commit/2034ec06f0c9fb419a194cbb23a18e2678076d29))
+
+
+### Bug Fixes
+
+* `yaml` not found in jsii languages ([39ef409](https://github.com/cdk8s-team/cdk8s-core/commit/39ef40935459e3cb910c11b07bec8fd474f45813))
+* allow tests to run without write access to os.tmpdir parent ([#338](https://github.com/cdk8s-team/cdk8s-core/issues/338)) ([dc17022](https://github.com/cdk8s-team/cdk8s-core/commit/dc1702207deb4367a1d05717a009851a7d3dac68))
+* **cdk8s:** autogenerated names fail validation for some resource types ([#18](https://github.com/cdk8s-team/cdk8s-core/issues/18)) ([b70e4fe](https://github.com/cdk8s-team/cdk8s-core/commit/b70e4fe5e8fdfc47e953d90d64337ff9f108fa39)), closes [#16](https://github.com/cdk8s-team/cdk8s-core/issues/16)
+* cli does not work when used from a symlink ([#11](https://github.com/cdk8s-team/cdk8s-core/issues/11)) ([4bd3a37](https://github.com/cdk8s-team/cdk8s-core/commit/4bd3a37625c4e13c68eb1561ed5fe7ebcb8c5a33))
+* **cli-init:** install "constructs" instead of "@aws-cdk/core" ([6ccc03f](https://github.com/cdk8s-team/cdk8s-core/commit/6ccc03fc9ee82ad292d4f8efd1d66447c67b1122))
+* **cli:** allow any python 3 to be used ([#518](https://github.com/cdk8s-team/cdk8s-core/issues/518)) ([2a49196](https://github.com/cdk8s-team/cdk8s-core/commit/2a491963547eab0b3348acae03fc5bf1db215794))
+* **cli:** Conform python and java package names to language standards (no hyphens) ([#283](https://github.com/cdk8s-team/cdk8s-core/issues/283)) ([f0b33c0](https://github.com/cdk8s-team/cdk8s-core/commit/f0b33c09e3f75cfc7e230605a9bb11d506ea4018))
+* **cli:** importing local files is broken on windows ([#427](https://github.com/cdk8s-team/cdk8s-core/issues/427)) ([2c4a185](https://github.com/cdk8s-team/cdk8s-core/commit/2c4a1858b5c88cf4e5eb6ac5e8f0bcb1495adbf4))
+* **cli:** impossible to import two crds with same kind ([#203](https://github.com/cdk8s-team/cdk8s-core/issues/203)) ([f6248ce](https://github.com/cdk8s-team/cdk8s-core/commit/f6248ce5b7f3004108f0449a319015c8d6e99df4))
+* **cli:** init could not find a version that matches cdk8s0-13-0 ([e1267f6](https://github.com/cdk8s-team/cdk8s-core/commit/e1267f608d8981578971564b1228be80e0e117e0))
+* **cli:** new typescript apps cannot be created with [@next](https://github.com/next) versions ([#55](https://github.com/cdk8s-team/cdk8s-core/issues/55)) ([119d95c](https://github.com/cdk8s-team/cdk8s-core/commit/119d95c78c3620be9adcd1cb5402e6f0ee901293))
+* **cli:** options type not generated for certain CRDs ([#229](https://github.com/cdk8s-team/cdk8s-core/issues/229)) ([0cbaf19](https://github.com/cdk8s-team/cdk8s-core/commit/0cbaf19c0d9f1cff6832c44c0699e20c83903a64)), closes [#219](https://github.com/cdk8s-team/cdk8s-core/issues/219)
+* **cli:** python init template doesn't install cdk8s-plus in the correct env ([#399](https://github.com/cdk8s-team/cdk8s-core/issues/399)) ([0d3017b](https://github.com/cdk8s-team/cdk8s-core/commit/0d3017b4285bb015d129cdf24c9e2da2d00f9025))
+* **cli:** python init templates are broken ([#393](https://github.com/cdk8s-team/cdk8s-core/issues/393)) ([d786001](https://github.com/cdk8s-team/cdk8s-core/commit/d786001edd0b91653d14aa687865f3e1eb68a88f))
+* **cli:** typescript-app does not include main.ts ([43b435a](https://github.com/cdk8s-team/cdk8s-core/commit/43b435a535f6d99f0ac0a3e570ebe95386c584ae))
+* **cli:** unable to import a crd that has no schema ([#132](https://github.com/cdk8s-team/cdk8s-core/issues/132)) ([b8115cb](https://github.com/cdk8s-team/cdk8s-core/commit/b8115cb809b2b33be73a98f99b1cefa4de152654))
+* **cli:** unable to import CRDs with non-trivial "xxxOf" constraints ([#212](https://github.com/cdk8s-team/cdk8s-core/issues/212)) ([18136ed](https://github.com/cdk8s-team/cdk8s-core/commit/18136ed26d833a27036b7cbf04fac4b8f7d9b542)), closes [#171](https://github.com/cdk8s-team/cdk8s-core/issues/171)
+* **cli:** unable to import types with all-caps TLAs ([#211](https://github.com/cdk8s-team/cdk8s-core/issues/211)) ([a11d0e8](https://github.com/cdk8s-team/cdk8s-core/commit/a11d0e8f8f8e5bbc745d9315086b97cbc49d2890)), closes [#209](https://github.com/cdk8s-team/cdk8s-core/issues/209)
+* **crd:** Ensure yaml doc is defined before casting to CustomResourceApiObject ([#130](https://github.com/cdk8s-team/cdk8s-core/issues/130)) ([03e6d84](https://github.com/cdk8s-team/cdk8s-core/commit/03e6d84ee5182d7e547d9b09d2d121daedb7f7c3))
+* **crd:** fix multi-resource importing of CRDs ([#78](https://github.com/cdk8s-team/cdk8s-core/issues/78)) ([fd8f753](https://github.com/cdk8s-team/cdk8s-core/commit/fd8f75359b37a6f76368d498f00d8dc615650423))
+* **crd:** import a CRD from an insecure server ([#102](https://github.com/cdk8s-team/cdk8s-core/issues/102)) ([4dde096](https://github.com/cdk8s-team/cdk8s-core/commit/4dde096419aadc1173835388d52f927e502f469a)), closes [#94](https://github.com/cdk8s-team/cdk8s-core/issues/94)
+* **docs:** align getting started with new code ([#410](https://github.com/cdk8s-team/cdk8s-core/issues/410)) ([c61e109](https://github.com/cdk8s-team/cdk8s-core/commit/c61e109e5cdddeb6c5c3b4ff86d2f7f79e11b9ff))
+* **docs:** correct logo paths ([#503](https://github.com/cdk8s-team/cdk8s-core/issues/503)) ([9426047](https://github.com/cdk8s-team/cdk8s-core/commit/94260473ef7c7e29799b4368981c8415dbd0fd8f))
+* **docs:** do not mark arguments as optional in python getting-started ([#191](https://github.com/cdk8s-team/cdk8s-core/issues/191)) ([be090d0](https://github.com/cdk8s-team/cdk8s-core/commit/be090d09b6bdc2105e21c2f6de0cdcc9da657b50))
+* **docs:** top-level "getting started" page not found ([#120](https://github.com/cdk8s-team/cdk8s-core/issues/120)) ([eb9d2ad](https://github.com/cdk8s-team/cdk8s-core/commit/eb9d2ad0e09f7bc8ba1ee2346aad2f3119d1f3e9)), closes [#106](https://github.com/cdk8s-team/cdk8s-core/issues/106)
+* **docs:** typo of helm doc ([#566](https://github.com/cdk8s-team/cdk8s-core/issues/566)) ([7d5c97e](https://github.com/cdk8s-team/cdk8s-core/commit/7d5c97e6f152f332cbb02f554d27ed542d319699))
+* **docs:** WebService typescript example formatting ([#408](https://github.com/cdk8s-team/cdk8s-core/issues/408)) ([e2470f9](https://github.com/cdk8s-team/cdk8s-core/commit/e2470f96e737af784f11168474ca24e52619c238))
+* **examples:** "replicas" option is not respected in the web-service example ([#87](https://github.com/cdk8s-team/cdk8s-core/issues/87)) ([97ca582](https://github.com/cdk8s-team/cdk8s-core/commit/97ca582b8a2fb0f1925518b0040acec9f32dd969))
+* **examples:** Add missing dependencies on python examples. ([#290](https://github.com/cdk8s-team/cdk8s-core/issues/290)) ([36e6fab](https://github.com/cdk8s-team/cdk8s-core/commit/36e6fab9c4c0f30f6f49c93c1f284d8054955fcd)), closes [#289](https://github.com/cdk8s-team/cdk8s-core/issues/289)
+* Fix yaml quote serialization 325 ([#327](https://github.com/cdk8s-team/cdk8s-core/issues/327)) ([6b1f662](https://github.com/cdk8s-team/cdk8s-core/commit/6b1f66278446efd01cb3d0b61a5fca712725fefa)), closes [#325](https://github.com/cdk8s-team/cdk8s-core/issues/325)
+* **gha:** Fix conditional homebrew release script ([5ecb143](https://github.com/cdk8s-team/cdk8s-core/commit/5ecb1434a8e4b2622cf3e001929a72c511ab89fa))
+* **gha:** prevent gha from running on forks ([26eb407](https://github.com/cdk8s-team/cdk8s-core/commit/26eb4076f1a786894f4d0efa7fa5883b6a444603))
+* **go:** invalid go module name ([87af61b](https://github.com/cdk8s-team/cdk8s-core/commit/87af61ba4e4942b4e1d01d3ee4f05bcea8d57e3a))
+* **imports:** Specify moduleName overrides for imports ([#84](https://github.com/cdk8s-team/cdk8s-core/issues/84)) ([63daf78](https://github.com/cdk8s-team/cdk8s-core/commit/63daf781d80690476b875785f7bb7beea2d5e029))
+* input type names are "XxxOptions" instead of "XxxProps" ([#381](https://github.com/cdk8s-team/cdk8s-core/issues/381)) ([b2bd34e](https://github.com/cdk8s-team/cdk8s-core/commit/b2bd34e43dc487673b7dce3061195465a5806f38)), closes [#371](https://github.com/cdk8s-team/cdk8s-core/issues/371)
+* java importing crd fails ([#257](https://github.com/cdk8s-team/cdk8s-core/issues/257)) ([f0ef3b4](https://github.com/cdk8s-team/cdk8s-core/commit/f0ef3b467969a90efcbfc663353565c8639bb5bd))
+* Lazy is not resolved in metadata ([#443](https://github.com/cdk8s-team/cdk8s-core/issues/443)) ([914d4a8](https://github.com/cdk8s-team/cdk8s-core/commit/914d4a89ace15a6081267cbf5d359459f8514ee9))
+* **lib:** `uniqueId` is not compatible with the k8s labels ([#326](https://github.com/cdk8s-team/cdk8s-core/issues/326)) ([161f368](https://github.com/cdk8s-team/cdk8s-core/commit/161f3682e9229cace25d3c283c98028f1e1ca0a6)), closes [#323](https://github.com/cdk8s-team/cdk8s-core/issues/323)
+* **lib:** corrupted manifests when including large files ([#350](https://github.com/cdk8s-team/cdk8s-core/issues/350)) ([649f41b](https://github.com/cdk8s-team/cdk8s-core/commit/649f41ba65a9bb7f8c7d0c4a260ae9ddd773afb8))
+* **lib:** deprecated toISOString() conflicts with toIsoString() ([#524](https://github.com/cdk8s-team/cdk8s-core/issues/524)) ([d4e0c3d](https://github.com/cdk8s-team/cdk8s-core/commit/d4e0c3d75c65ec91908327fbb7ce24d7d6981b9e))
+* **lib:** duplicate hyphens in generated resource names ([#341](https://github.com/cdk8s-team/cdk8s-core/issues/341)) ([6f6366a](https://github.com/cdk8s-team/cdk8s-core/commit/6f6366a55c31f6ec9af09f33effcfa52a1b23fe8))
+* **lib:** ENOBUFS for large helm charts ([#529](https://github.com/cdk8s-team/cdk8s-core/issues/529)) ([4164f38](https://github.com/cdk8s-team/cdk8s-core/commit/4164f38706b5a2bb65aff0224df6e133e217f070)), closes [#454](https://github.com/cdk8s-team/cdk8s-core/issues/454)
+* **lib:** fail to import octal numbers via include (and helm) ([#349](https://github.com/cdk8s-team/cdk8s-core/issues/349)) ([bed9eed](https://github.com/cdk8s-team/cdk8s-core/commit/bed9eedd31e07bd00461d6e54c798bf43fc65ede)), closes [#348](https://github.com/cdk8s-team/cdk8s-core/issues/348)
+* **lib:** names generated using non-FIPS compliant algorithm ([#392](https://github.com/cdk8s-team/cdk8s-core/issues/392)) ([a1acae7](https://github.com/cdk8s-team/cdk8s-core/commit/a1acae7a1b935fc06a15c820bf28619d1e4c0f37)), closes [#334](https://github.com/cdk8s-team/cdk8s-core/issues/334)
+* **lib:** unable to express empty objects and array ([#200](https://github.com/cdk8s-team/cdk8s-core/issues/200)) ([9ae5efb](https://github.com/cdk8s-team/cdk8s-core/commit/9ae5efb9834e1608ae196db88680a34005ac7203))
+* move output of java imports into /src/main/java ([#240](https://github.com/cdk8s-team/cdk8s-core/issues/240)) ([9445358](https://github.com/cdk8s-team/cdk8s-core/commit/94453588a504fe35dd4da7b7c6d9b92a1d93c4f3))
+* multiline string with line greater than 80 characters lose newlines ([#589](https://github.com/cdk8s-team/cdk8s-core/issues/589)) ([e95b8a1](https://github.com/cdk8s-team/cdk8s-core/commit/e95b8a1783ce020e7913cbf58ad8efd39db1a6c4)), closes [#588](https://github.com/cdk8s-team/cdk8s-core/issues/588)
+* not folding strings ([#495](https://github.com/cdk8s-team/cdk8s-core/issues/495)) ([8dda8bd](https://github.com/cdk8s-team/cdk8s-core/commit/8dda8bdac90f9254fa95a736a1b29c87609934df)), closes [#494](https://github.com/cdk8s-team/cdk8s-core/issues/494)
+* **plus-17:** adds externalName to service props ([#424](https://github.com/cdk8s-team/cdk8s-core/issues/424)) ([b4b7c55](https://github.com/cdk8s-team/cdk8s-core/commit/b4b7c55134ffc14203a58eb72227251225c79cc3))
+* **plus-17:** don't allow containers to be contructed from containers ([#404](https://github.com/cdk8s-team/cdk8s-core/issues/404)) ([5d11533](https://github.com/cdk8s-team/cdk8s-core/commit/5d11533f9aea672793459b9f2c6caaddb6430e3e))
+* **plus-17:** L2 default child ([#389](https://github.com/cdk8s-team/cdk8s-core/issues/389)) ([a8337e8](https://github.com/cdk8s-team/cdk8s-core/commit/a8337e805dce81e0d0883bb296c1017b5ac2311f))
+* **plus-17:** multiple mounts per volume result in duplicate volumes for pod spec ([#489](https://github.com/cdk8s-team/cdk8s-core/issues/489)) ([47c913e](https://github.com/cdk8s-team/cdk8s-core/commit/47c913e1abc026611332fcf03b209adda7aba419))
+* **plus:** support node ports for cdk8s-plus service ([#315](https://github.com/cdk8s-team/cdk8s-core/issues/315)) ([85ec225](https://github.com/cdk8s-team/cdk8s-core/commit/85ec225bcdbab3631ffebbf6c93c3ac70937b4b9)), closes [#296](https://github.com/cdk8s-team/cdk8s-core/issues/296)
+* **readme:** hello example link is broken [#74](https://github.com/cdk8s-team/cdk8s-core/issues/74) ([0b858cf](https://github.com/cdk8s-team/cdk8s-core/commit/0b858cfd8d1306be67394cb733984b8b49dfcc06))
+* **readme:** missing information about imports in cdk8s-cli readme ([#108](https://github.com/cdk8s-team/cdk8s-core/issues/108)) ([e9f291e](https://github.com/cdk8s-team/cdk8s-core/commit/e9f291e8da8beebc1bb26b20078ed0d3675ce580))
+* **redirect:** Handle 302 redirect case when importing from remote url ([#131](https://github.com/cdk8s-team/cdk8s-core/issues/131)) ([1ed88ca](https://github.com/cdk8s-team/cdk8s-core/commit/1ed88ca32c998b590093fd0090ecbf9a6662043e))
+* set yaml default schema to 1.1 ([#505](https://github.com/cdk8s-team/cdk8s-core/issues/505)) ([266c094](https://github.com/cdk8s-team/cdk8s-core/commit/266c094b19231e3beea836a6d77842954077d4f1))
+* union types could not be synthesized ([5a47262](https://github.com/cdk8s-team/cdk8s-core/commit/5a47262e4f55ac9b1f13bcbfbc9cdf1efd3a1b7b))
+* **website:** doc links are broken due to wrong version number ([#312](https://github.com/cdk8s-team/cdk8s-core/issues/312)) ([f2f9402](https://github.com/cdk8s-team/cdk8s-core/commit/f2f9402d975aa9a2b8bab6db68fc8bccb74a6772)), closes [#307](https://github.com/cdk8s-team/cdk8s-core/issues/307)
+* which command missing for windows ([#417](https://github.com/cdk8s-team/cdk8s-core/issues/417)) ([38a7034](https://github.com/cdk8s-team/cdk8s-core/commit/38a703411c7162bfa4d1904ef6b94e2a017ea4da))
+
+
+### Miscellaneous Chores
+
+* upgrade jsii & constructs ([#80](https://github.com/cdk8s-team/cdk8s-core/issues/80)) ([f917e0a](https://github.com/cdk8s-team/cdk8s-core/commit/f917e0a29490eb0369d4583a7303f1fded7f6693))
+
+
+### Code Refactoring
+
+* **plus:** Remove the `spec` nesting level on both input and output ([#347](https://github.com/cdk8s-team/cdk8s-core/issues/347)) ([5e34850](https://github.com/cdk8s-team/cdk8s-core/commit/5e34850f4b3cc9c80fda4f0df245afcaa29b1daf))
+


### PR DESCRIPTION
This repository was created utilizing Projen and I believe there is not way of auto generating a Changelog utilizing projen. 

Using the same [library's](https://github.com/conventional-changelog/conventional-changelog) CLI as AWS CDK for generating changelog for this repository.

## DCO
Signed-off-by: Vinayak Kukreja <vinakuk@amazon.com>