### PR TITLE
fix: app `outdir` property cannot be different from CLI or cdk8s.yaml file

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -217,10 +217,11 @@ App.Builder.create()
 
 The directory to output Kubernetes manifests.
 
-By default, the value you pass to the CDK8s CLI's `--output` flag
-or in the `output` property of cdk8s.yaml file will be used,
-and if you change it to a different directory the CLI will fail
-to pick up the new output directory.
+If you synthesize your application using `cdk8s synth`, you must
+also pass this value to the CLI using the `--output` option or
+the `output` property in the `cdk8s.yaml` configuration file.
+Otherwise, the CLI will not know about the output directory,
+and synthesis will fail.
 
 This property is intended for internal and testing use.
 
@@ -851,10 +852,11 @@ public java.lang.String getOutdir();
 
 The directory to output Kubernetes manifests.
 
-By default, the value you pass to the CDK8s CLI's `--output` flag
-or in the `output` property of cdk8s.yaml file will be used,
-and if you change it to a different directory the CLI will fail
-to pick up the new output directory.
+If you synthesize your application using `cdk8s synth`, you must
+also pass this value to the CLI using the `--output` option or
+the `output` property in the `cdk8s.yaml` configuration file.
+Otherwise, the CLI will not know about the output directory,
+and synthesis will fail.
 
 This property is intended for internal and testing use.
 

--- a/docs/java.md
+++ b/docs/java.md
@@ -217,6 +217,13 @@ App.Builder.create()
 
 The directory to output Kubernetes manifests.
 
+By default, the value you pass to the CDK8s CLI's `--output` flag
+or in the `output` property of cdk8s.yaml file will be used,
+and if you change it to a different directory the CLI will fail
+to pick up the new output directory.
+
+This property is intended for internal and testing use.
+
 ---
 
 ##### `outputFileExtension`<sup>Optional</sup> <a name="org.cdk8s.AppProps.parameter.outputFileExtension"></a>
@@ -843,6 +850,13 @@ public java.lang.String getOutdir();
 - *Default:* CDK8S_OUTDIR if defined, otherwise "dist"
 
 The directory to output Kubernetes manifests.
+
+By default, the value you pass to the CDK8s CLI's `--output` flag
+or in the `output` property of cdk8s.yaml file will be used,
+and if you change it to a different directory the CLI will fail
+to pick up the new output directory.
+
+This property is intended for internal and testing use.
 
 ---
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -225,6 +225,13 @@ cdk8s.App(
 
 The directory to output Kubernetes manifests.
 
+By default, the value you pass to the CDK8s CLI's `--output` flag
+or in the `output` property of cdk8s.yaml file will be used,
+and if you change it to a different directory the CLI will fail
+to pick up the new output directory.
+
+This property is intended for internal and testing use.
+
 ---
 
 ##### `output_file_extension`<sup>Optional</sup> <a name="cdk8s.AppProps.parameter.output_file_extension"></a>
@@ -865,6 +872,13 @@ outdir: str
 - *Default:* CDK8S_OUTDIR if defined, otherwise "dist"
 
 The directory to output Kubernetes manifests.
+
+By default, the value you pass to the CDK8s CLI's `--output` flag
+or in the `output` property of cdk8s.yaml file will be used,
+and if you change it to a different directory the CLI will fail
+to pick up the new output directory.
+
+This property is intended for internal and testing use.
 
 ---
 
@@ -2853,6 +2867,13 @@ cdk8s.Testing.app(
 - *Default:* CDK8S_OUTDIR if defined, otherwise "dist"
 
 The directory to output Kubernetes manifests.
+
+By default, the value you pass to the CDK8s CLI's `--output` flag
+or in the `output` property of cdk8s.yaml file will be used,
+and if you change it to a different directory the CLI will fail
+to pick up the new output directory.
+
+This property is intended for internal and testing use.
 
 ---
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -225,10 +225,11 @@ cdk8s.App(
 
 The directory to output Kubernetes manifests.
 
-By default, the value you pass to the CDK8s CLI's `--output` flag
-or in the `output` property of cdk8s.yaml file will be used,
-and if you change it to a different directory the CLI will fail
-to pick up the new output directory.
+If you synthesize your application using `cdk8s synth`, you must
+also pass this value to the CLI using the `--output` option or
+the `output` property in the `cdk8s.yaml` configuration file.
+Otherwise, the CLI will not know about the output directory,
+and synthesis will fail.
 
 This property is intended for internal and testing use.
 
@@ -873,10 +874,11 @@ outdir: str
 
 The directory to output Kubernetes manifests.
 
-By default, the value you pass to the CDK8s CLI's `--output` flag
-or in the `output` property of cdk8s.yaml file will be used,
-and if you change it to a different directory the CLI will fail
-to pick up the new output directory.
+If you synthesize your application using `cdk8s synth`, you must
+also pass this value to the CLI using the `--output` option or
+the `output` property in the `cdk8s.yaml` configuration file.
+Otherwise, the CLI will not know about the output directory,
+and synthesis will fail.
 
 This property is intended for internal and testing use.
 
@@ -2868,10 +2870,11 @@ cdk8s.Testing.app(
 
 The directory to output Kubernetes manifests.
 
-By default, the value you pass to the CDK8s CLI's `--output` flag
-or in the `output` property of cdk8s.yaml file will be used,
-and if you change it to a different directory the CLI will fail
-to pick up the new output directory.
+If you synthesize your application using `cdk8s synth`, you must
+also pass this value to the CLI using the `--output` option or
+the `output` property in the `cdk8s.yaml` configuration file.
+Otherwise, the CLI will not know about the output directory,
+and synthesis will fail.
 
 This property is intended for internal and testing use.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -702,10 +702,11 @@ public readonly outdir: string;
 
 The directory to output Kubernetes manifests.
 
-By default, the value you pass to the CDK8s CLI's `--output` flag
-or in the `output` property of cdk8s.yaml file will be used,
-and if you change it to a different directory the CLI will fail
-to pick up the new output directory.
+If you synthesize your application using `cdk8s synth`, you must
+also pass this value to the CLI using the `--output` option or
+the `output` property in the `cdk8s.yaml` configuration file.
+Otherwise, the CLI will not know about the output directory,
+and synthesis will fail.
 
 This property is intended for internal and testing use.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -702,6 +702,13 @@ public readonly outdir: string;
 
 The directory to output Kubernetes manifests.
 
+By default, the value you pass to the CDK8s CLI's `--output` flag
+or in the `output` property of cdk8s.yaml file will be used,
+and if you change it to a different directory the CLI will fail
+to pick up the new output directory.
+
+This property is intended for internal and testing use.
+
 ---
 
 ##### `outputFileExtension`<sup>Optional</sup> <a name="cdk8s.AppProps.property.outputFileExtension"></a>

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,10 +23,11 @@ export interface AppProps {
   /**
    * The directory to output Kubernetes manifests.
    *
-   * By default, the value you pass to the CDK8s CLI's `--output` flag
-   * or in the `output` property of cdk8s.yaml file will be used,
-   * and if you change it to a different directory the CLI will fail
-   * to pick up the new output directory.
+   * If you synthesize your application using `cdk8s synth`, you must
+   * also pass this value to the CLI using the `--output` option or
+   * the `output` property in the `cdk8s.yaml` configuration file.
+   * Otherwise, the CLI will not know about the output directory,
+   * and synthesis will fail.
    *
    * This property is intended for internal and testing use.
    *

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,13 @@ export interface AppProps {
   /**
    * The directory to output Kubernetes manifests.
    *
+   * By default, the value you pass to the CDK8s CLI's `--output` flag
+   * or in the `output` property of cdk8s.yaml file will be used,
+   * and if you change it to a different directory the CLI will fail
+   * to pick up the new output directory.
+   *
+   * This property is intended for internal and testing use.
+   *
    * @default - CDK8S_OUTDIR if defined, otherwise "dist"
    */
   readonly outdir?: string;


### PR DESCRIPTION
Currently setting the `outdir` property for CDK8s app throws an error,
```
ERROR: synthesis failed, app expected to create "dist"
```

This is due to the CLI not able to recognize this change in the `outdir` in the application property. 
The value specified in the `outdir` needs to be similar to what is mentioned either in CLI's `--output` argument or the `output` property in the cdk8s.yaml file. 

Signed-off-by: Vinayak Kukreja <vinakuk@amazon.com>

Resolves https://github.com/cdk8s-team/cdk8s-cli/issues/210