### PR TITLE
fix: multiple calls to `toJson` cause unexpected json patches

### DIFF
--- a/src/json-patch.ts
+++ b/src/json-patch.ts
@@ -1,4 +1,4 @@
-import { applyPatch, Operation } from 'fast-json-patch';
+import { applyPatch, deepClone, Operation } from 'fast-json-patch';
 
 /**
  * Utility for applying RFC-6902 JSON-Patch to a document.
@@ -25,7 +25,7 @@ export class JsonPatch {
    * @returns The result document
    */
   public static apply(document: any, ...ops: JsonPatch[]): any {
-    const result = applyPatch(document, ops.map(o => o._toJson()));
+    const result = applyPatch(document, deepClone(ops.map(o => o._toJson())));
     return result.newDocument;
   }
 

--- a/test/json-patch.test.ts
+++ b/test/json-patch.test.ts
@@ -52,3 +52,18 @@ test('apply()', () => {
     },
   });
 });
+
+test('apply() does not mutate the patches', () => {
+  const input = {
+    world: {},
+  };
+
+  const patches = [
+    JsonPatch.add('/world/foo', []),
+    JsonPatch.add('/world/foo/-', 'boom'),
+  ];
+
+  JsonPatch.apply(input, ...patches);
+
+  expect(patches[0]._toJson()).toEqual(JsonPatch.add('/world/foo', [])._toJson());
+});


### PR DESCRIPTION
Signed-off-by: Nathanael Law <njlaw@xyrodian.com>

Fixes cdk8s-team/cdk8s-core#954
