### PR TITLE
feat(app): hook into synthesis with `chart.toJson` (#1053)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Construct, Node, IConstruct } from 'constructs';
+import { Construct, IConstruct, Node } from 'constructs';
 import { ApiObject } from './api-object';
 import { Chart } from './chart';
 import { DependencyGraph } from './dependency';
@@ -159,17 +159,16 @@ export class App extends Construct {
 
     switch (this.yamlOutputType) {
       case YamlOutputType.FILE_PER_APP:
-        let apiObjectList: ApiObject[] = [];
+        let apiObjectsList: ApiObject[] = [];
 
         for (const chart of charts) {
-          apiObjectList.push(...chartToKube(chart));
+          apiObjectsList.push(...Object.values(chart.toJson()));
         }
 
         if (charts.length > 0) {
           Yaml.save(
             path.join(this.outdir, `app${this.outputFileExtension}`), // There is no "app name", so we just hardcode the file name
-            apiObjectList.map((apiObject) => apiObject.toJson()),
-          );
+            apiObjectsList);
         }
         break;
 
@@ -177,20 +176,20 @@ export class App extends Construct {
         const namer: ChartNamer = hasDependantCharts ? new IndexedChartNamer() : new SimpleChartNamer();
         for (const chart of charts) {
           const chartName = namer.name(chart);
-          const objects = chartToKube(chart);
-          Yaml.save(path.join(this.outdir, chartName+this.outputFileExtension), objects.map(obj => obj.toJson()));
+          const objects = Object.values(chart.toJson());
+          Yaml.save(path.join(this.outdir, chartName+this.outputFileExtension), objects);
         }
         break;
 
       case YamlOutputType.FILE_PER_RESOURCE:
         for (const chart of charts) {
-          const apiObjects = chartToKube(chart);
+          const apiObjects = Object.values(chart.toJson());
 
           apiObjects.forEach((apiObject) => {
             if (!(apiObject === undefined)) {
               const fileName = `${`${apiObject.kind}.${apiObject.metadata.name}`
                 .replace(/[^0-9a-zA-Z-_.]/g, '')}`;
-              Yaml.save(path.join(this.outdir, fileName+this.outputFileExtension), [apiObject.toJson()]);
+              Yaml.save(path.join(this.outdir, fileName+this.outputFileExtension), [apiObject]);
             }
           });
         }
@@ -230,15 +229,17 @@ export class App extends Construct {
    *
    * @returns A string with all YAML objects across all charts in this app.
    */
-  public synthYaml(): any {
+  public synthYaml(): string {
+
+    resolveDependencies(this);
+
     validate(this);
 
     const charts = this.charts;
     const docs: any[] = [];
 
     for (const chart of charts) {
-      const apiObjects = chartToKube(chart);
-      docs.push(...apiObjects.map(apiObject => apiObject.toJson()));
+      docs.push(...Object.values(chart.toJson()));
     }
 
     return Yaml.stringify(...docs);
@@ -271,21 +272,17 @@ function resolveDependencies(app: App) {
 
   let hasDependantCharts = false;
 
+  // create an explicit chart dependency from nested chart relationships
+  for (const parentChart of Node.of(app).findAll().filter(x => x instanceof Chart)) {
+    for (const childChart of Node.of(parentChart).children.filter(x => x instanceof Chart)) {
+      Node.of(parentChart).addDependency(childChart);
+      hasDependantCharts = true;
+    }
+  }
+
+  // create an explicit chart dependency from implicit construct dependencies
   for (const dep of Node.of(app).dependencies) {
 
-    // create explicit api object dependencies from implicit construct dependencies
-    const targetApiObjects = Node.of(dep.target).findAll().filter(c => c instanceof ApiObject);
-    const sourceApiObjects = Node.of(dep.source).findAll().filter(c => c instanceof ApiObject);
-
-    for (const target of targetApiObjects) {
-      for (const source of sourceApiObjects) {
-        if (target !== source) {
-          Node.of(source).addDependency(target);
-        }
-      }
-    }
-
-    // create an explicit chart dependency from implicit construct dependencies
     const sourceChart = Chart.of(dep.source);
     const targetChart = Chart.of(dep.target);
 
@@ -296,14 +293,21 @@ function resolveDependencies(app: App) {
 
   }
 
-  const charts = new DependencyGraph(Node.of(app)).topology()
-    .filter(x => x instanceof Chart);
+  // create explicit api object dependencies from implicit construct dependencies
+  for (const dep of Node.of(app).dependencies) {
 
-  for (const parentChart of charts) {
-    for (const childChart of Node.of(parentChart).children.filter(x => x instanceof Chart)) {
-      // create an explicit chart dependency from nested chart relationships
-      Node.of(parentChart).addDependency(childChart);
-      hasDependantCharts = true;
+    const sourceChart = Chart.of(dep.source);
+    const targetChart = Chart.of(dep.target);
+
+    const targetApiObjects = Node.of(dep.target).findAll().filter(c => c instanceof ApiObject).filter(x => Chart.of(x) === targetChart);
+    const sourceApiObjects = Node.of(dep.source).findAll().filter(c => c instanceof ApiObject).filter(x => Chart.of(x) === sourceChart);
+
+    for (const target of targetApiObjects) {
+      for (const source of sourceApiObjects) {
+        if (target !== source) {
+          Node.of(source).addDependency(target);
+        }
+      }
     }
   }
 

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -1,4 +1,4 @@
-import { Construct, Node, IConstruct } from 'constructs';
+import { Construct, IConstruct, Node } from 'constructs';
 import { ApiObject } from './api-object';
 import { App } from './app';
 import { Names } from './names';

--- a/test/__snapshots__/app.test.ts.snap
+++ b/test/__snapshots__/app.test.ts.snap
@@ -40,6 +40,14 @@ metadata:
 "
 `;
 
+exports[`can hook into chart synthesis with during synth 1`] = `
+"apiVersion: v1
+kind: Kind2
+metadata:
+  name: chart-apiobject2-c81f1ca2
+"
+`;
+
 exports[`return app as yaml string 1`] = `
 "apiVersion: v1
 kind: Kind1
@@ -60,5 +68,18 @@ apiVersion: v1
 kind: Kind4
 metadata:
   name: chart3-obj4-c8da728e
+"
+`;
+
+exports[`synthYaml considers dependencies 1`] = `
+"apiVersion: v1
+kind: Kind2
+metadata:
+  name: chart-c2-apiobject2-c8a49d62
+---
+apiVersion: v1
+kind: Kind1
+metadata:
+  name: chart-c1-apiobject1-c8f49fa2
 "
 `;

--- a/test/dependency.test.ts
+++ b/test/dependency.test.ts
@@ -1,4 +1,4 @@
-import { Node, IConstruct, Construct } from 'constructs';
+import { IConstruct, Construct, Node } from 'constructs';
 import { DependencyGraph } from '../src/dependency';
 
 test('topology returns correct order', () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `2.x` to `1.x`:
 - [feat(app): hook into synthesis with `chart.toJson` (#1053)](https://github.com/cdk8s-team/cdk8s-core/pull/1053)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)