### PR TITLE
chore: fix go 1.x is not released

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,5 +9,5 @@ contact_links:
     url: https://cloud-native.slack.com/archives/C02KCDACGTT
     about: Please ask and answer questions here.
   - name: GitHub Community Support
-    url: https://github.com/cdk8s-team/cdk8s/discussions
+    url: https://github.com/cdk8s-team/cdk8s-core/discussions
     about: Please ask and answer questions here.

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -3,6 +3,7 @@ const { JsonFile, github } = require('projen');
 
 const project = new Cdk8sTeamJsiiProject({
   name: 'cdk8s',
+  repoName: 'cdk8s-core',
   description: 'This is the core library of Cloud Development Kit (CDK) for Kubernetes (cdk8s). cdk8s apps synthesize into standard Kubernetes manifests which can be applied to any Kubernetes cluster.',
   projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
   peerDeps: [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "This is the core library of Cloud Development Kit (CDK) for Kubernetes (cdk8s). cdk8s apps synthesize into standard Kubernetes manifests which can be applied to any Kubernetes cluster.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cdk8s-team/cdk8s.git"
+    "url": "https://github.com/cdk8s-team/cdk8s-core.git"
   },
   "scripts": {
     "backport": "npx projen backport",
@@ -157,7 +157,7 @@
         "packageId": "Org.Cdk8s"
       },
       "go": {
-        "moduleName": "github.com/cdk8s-team/cdk8s-go"
+        "moduleName": "github.com/cdk8s-team/cdk8s-core-go"
       }
     },
     "tsc": {


### PR DESCRIPTION
Basically reverting the repo change that was introduced in this commit https://github.com/cdk8s-team/cdk8s-core/commit/30f2cf6b0aa53a166efded97bece284a2cef5218

Fixes 1.x releases not happening for a week or so.
See https://github.com/cdk8s-team/cdk8s-core/actions/runs/4277604953