### PR TITLE
chore(backport): use `ubuntu-latest` in workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
       - closed
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -101,7 +101,7 @@ for (const branch of project.release.branches) {
 const backportWorkflow = project.github.addWorkflow('backport');
 backportWorkflow.on({ pullRequestTarget: { types: ['closed'] } });
 backportWorkflow.addJob('backport', {
-  runsOn: ['ubuntu-18.04'],
+  runsOn: ['ubuntu-latest'],
   permissions: {
     contents: github.workflows.JobPermission.WRITE,
   },


### PR DESCRIPTION
Backporting https://github.com/cdk8s-team/cdk8s-core/pull/1079 failed because it uses `ubuntu-18.04` and there is a scheduled brownout period right now. 

```console
This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023. For more details, see https://github.com/actions/runner-images/issues/6002
```

Lets just use `ubuntu-latest`.