### PR TITLE
fix(chart): generated names for `CronJob` resources can be too long

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -4,6 +4,7 @@ import { App } from './app';
 import { Names } from './names';
 
 const CHART_SYMBOL = Symbol.for('cdk8s.Chart');
+const CRONJOB = 'CronJob';
 
 export interface ChartProps {
   /**
@@ -115,6 +116,7 @@ export class Chart extends Construct {
   public generateObjectName(apiObject: ApiObject) {
     return Names.toDnsLabel(apiObject, {
       includeHash: !this._disableResourceNameHashes,
+      maxLen: apiObject.kind == CRONJOB ? 52 : undefined,
     });
   }
 

--- a/test/chart.test.ts
+++ b/test/chart.test.ts
@@ -66,7 +66,7 @@ test('output includes all synthesized resources', () => {
   expect(Testing.synth(chart)).toMatchSnapshot();
 });
 
-test('CronJob names are less than 52 characters', () => {
+test('CronJob names are at most 52 characters', () => {
   // GIVEN
   const app = Testing.app();
   const chart = new Chart(app, 'test');

--- a/test/chart.test.ts
+++ b/test/chart.test.ts
@@ -66,6 +66,19 @@ test('output includes all synthesized resources', () => {
   expect(Testing.synth(chart)).toMatchSnapshot();
 });
 
+test('CronJob names are less than 52 characters', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'test');
+
+  // WHEN
+  const ob1 = new ApiObject(chart, 'cj1', { kind: 'CronJob', apiVersion: 'v1' });
+  const ob2 = new ApiObject(chart, 'resourceNameThatIsLongerThan52Charactersssssssssssss', { kind: 'CronJob', apiVersion: 'v1' });
+
+  // THEN
+  expect(ob1.name.length).toBeLessThanOrEqual(52);
+  expect(ob2.name.length).toBeLessThanOrEqual(52);
+});
 
 test('tokens are resolved during synth', () => {
   // GIVEN


### PR DESCRIPTION
Fixes #761 

Currently, generated`CronJob` names in cdk8s have a maximum length of 63 characters. However, `CronJob` names should actually have a maximum length of 52 characters (since the CronJob controller in Kubernetes automatically appends 11 characters to the name you provide -- [see the K8s CronJob documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)). This PR fixes this issue by setting the maximum length of `CronJob` objects to 52.

Added the test "CronJob names are at most 52 characters" in `test/chart.test.ts` to validate these changes.