### PR TITLE
fix(api-object): cross-module-version `instanceof` is broken

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -97,6 +97,22 @@ public toJson()
 
 #### Static Functions <a name="Static Functions"></a>
 
+##### `isApiObject` <a name="org.cdk8s.ApiObject.isApiObject"></a>
+
+```java
+import org.cdk8s.ApiObject;
+
+ApiObject.isApiObject(java.lang.Object o)
+```
+
+###### `o`<sup>Required</sup> <a name="org.cdk8s.ApiObject.parameter.o"></a>
+
+- *Type:* `java.lang.Object`
+
+The object to check.
+
+---
+
 ##### `of` <a name="org.cdk8s.ApiObject.of"></a>
 
 ```java

--- a/docs/python.md
+++ b/docs/python.md
@@ -103,6 +103,24 @@ def to_json()
 
 #### Static Functions <a name="Static Functions"></a>
 
+##### `is_api_object` <a name="cdk8s.ApiObject.is_api_object"></a>
+
+```python
+import cdk8s
+
+cdk8s.ApiObject.is_api_object(
+  o: typing.Any
+)
+```
+
+###### `o`<sup>Required</sup> <a name="cdk8s.ApiObject.parameter.o"></a>
+
+- *Type:* `typing.Any`
+
+The object to check.
+
+---
+
 ##### `of` <a name="cdk8s.ApiObject.of"></a>
 
 ```python

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -74,6 +74,22 @@ public toJson()
 
 #### Static Functions <a name="Static Functions"></a>
 
+##### `isApiObject` <a name="cdk8s.ApiObject.isApiObject"></a>
+
+```typescript
+import { ApiObject } from 'cdk8s'
+
+ApiObject.isApiObject(o: any)
+```
+
+###### `o`<sup>Required</sup> <a name="cdk8s.ApiObject.parameter.o"></a>
+
+- *Type:* `any`
+
+The object to check.
+
+---
+
 ##### `of` <a name="cdk8s.ApiObject.of"></a>
 
 ```typescript

--- a/src/api-object.ts
+++ b/src/api-object.ts
@@ -64,6 +64,7 @@ export class ApiObject extends Construct {
    * Implements `instanceof ApiObject` using the more reliable `ApiObject.isApiObject` static method
    *
    * @param o The object to check
+   * @internal
    */
   static [Symbol.hasInstance](o: unknown) {
     return ApiObject.isApiObject(o);

--- a/src/api-object.ts
+++ b/src/api-object.ts
@@ -56,8 +56,8 @@ export class ApiObject extends Construct {
 
    * @param o The object to check
    */
-  static isApiObject(o: unknown): o is ApiObject {
-    return o != null && typeof o === 'object' && API_OBJECT_SYMBOL in o;
+  static isApiObject(o: any): o is ApiObject {
+    return o !== null && typeof o === 'object' && API_OBJECT_SYMBOL in o;
   }
 
   /**

--- a/src/api-object.ts
+++ b/src/api-object.ts
@@ -45,7 +45,29 @@ export interface GroupVersionKind {
   readonly kind: string;
 }
 
+const API_OBJECT_SYMBOL = Symbol.for('cdk8s.ApiObject');
+
 export class ApiObject extends Construct {
+
+  /**
+   * Return whether the given object is an `ApiObject`.
+   *
+   * We do attribute detection since we can't reliably use 'instanceof'.
+
+   * @param o The object to check
+   */
+  static isApiObject(o: unknown): o is ApiObject {
+    return o != null && typeof o === 'object' && API_OBJECT_SYMBOL in o;
+  }
+
+  /**
+   * Implements `instanceof ApiObject` using the more reliable `ApiObject.isApiObject` static method
+   *
+   * @param o The object to check
+   */
+  static [Symbol.hasInstance](o: unknown) {
+    return ApiObject.isApiObject(o);
+  }
   /**
    * Returns the `ApiObject` named `Resource` which is a child of the given
    * construct. If `c` is an `ApiObject`, it is returned directly. Throws an
@@ -137,6 +159,7 @@ export class ApiObject extends Construct {
       },
     });
 
+    Object.defineProperty(this, API_OBJECT_SYMBOL, { value: true });
   }
 
   /**

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -43,6 +43,16 @@ export class Chart extends Construct {
   }
 
   /**
+   * Implements `instanceof Chart` using the more reliable `Chart.isChart` static method
+   *
+   * @param o The object to check
+   * @internal
+   */
+  static [Symbol.hasInstance](o: unknown) {
+    return Chart.isChart(o);
+  }
+
+  /**
    * Finds the chart in which a node is defined.
    * @param c a construct node
    */


### PR DESCRIPTION
This pull request fixes the issue with `instanceof` (https://github.com/cdk8s-team/cdk8s-core/issues/581) by implementing `Symbol.hasInstance` (thanks to @fikisipi for pointing it out)

Docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance

I welcome any ideas on how to write tests demonstrating the issue is fixed, as to set things up one needs to have multiple versions (or instances) of the same module.

Fixes https://github.com/cdk8s-team/cdk8s-core/issues/581
