### PR TITLE
fix(chart): generated names for `CronJob` resources can be too long (#1109)

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -4,6 +4,7 @@ import { App } from './app';
 import { Names } from './names';
 
 const CHART_SYMBOL = Symbol.for('cdk8s.Chart');
+const CRONJOB = 'CronJob';
 
 export interface ChartProps {
   /**
@@ -115,6 +116,7 @@ export class Chart extends Construct {
   public generateObjectName(apiObject: ApiObject) {
     return Names.toDnsLabel(apiObject, {
       includeHash: !this._disableResourceNameHashes,
+      maxLen: apiObject.kind == CRONJOB ? 52 : undefined,
     });
   }
 

--- a/test/chart.test.ts
+++ b/test/chart.test.ts
@@ -66,6 +66,19 @@ test('output includes all synthesized resources', () => {
   expect(Testing.synth(chart)).toMatchSnapshot();
 });
 
+test('CronJob names are at most 52 characters', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'test');
+
+  // WHEN
+  const ob1 = new ApiObject(chart, 'cj1', { kind: 'CronJob', apiVersion: 'v1' });
+  const ob2 = new ApiObject(chart, 'resourceNameThatIsLongerThan52Charactersssssssssssss', { kind: 'CronJob', apiVersion: 'v1' });
+
+  // THEN
+  expect(ob1.name.length).toBeLessThanOrEqual(52);
+  expect(ob2.name.length).toBeLessThanOrEqual(52);
+});
 
 test('tokens are resolved during synth', () => {
   // GIVEN


### PR DESCRIPTION
# Backport

This will backport the following commits from `2.x` to `1.x`:
 - [fix(chart): generated names for `CronJob` resources can be too long (#1109)](https://github.com/cdk8s-team/cdk8s-core/pull/1109)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)