### PR TITLE
fix(app): create `validations/` subdirectory in `dist/` for the `construct-metadata.json` file

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -250,7 +250,7 @@ export class App extends Construct {
     for (const apiObject of apiObjects) {
       resources[apiObject.name] = { path: apiObject.node.path };
     }
-    fs.writeFileSync(path.join(this.outdir, 'construct-metadata.json'), JSON.stringify({
+    fs.writeFileSync(path.join(this.outdir, 'metadata/construct-metadata.json'), JSON.stringify({
       version: '1.0.0',
       resources: resources,
     }));

--- a/src/app.ts
+++ b/src/app.ts
@@ -250,7 +250,7 @@ export class App extends Construct {
     for (const apiObject of apiObjects) {
       resources[apiObject.name] = { path: apiObject.node.path };
     }
-    fs.writeFileSync(path.join(this.outdir, 'metadata/construct-metadata.json'), JSON.stringify({
+    fs.writeFileSync(path.join(this.outdir, 'validation/construct-metadata.json'), JSON.stringify({
       version: '1.0.0',
       resources: resources,
     }));

--- a/test/chart.test.ts
+++ b/test/chart.test.ts
@@ -365,7 +365,7 @@ test('construct metadata is recorded when requested by api', () => {
 
   app.synth();
 
-  const constructMetadata = JSON.parse(fs.readFileSync(path.join(app.outdir, 'construct-metadata.json'), { encoding: 'utf-8' }));
+  const constructMetadata = JSON.parse(fs.readFileSync(path.join(app.outdir, 'validation/construct-metadata.json'), { encoding: 'utf-8' }));
   expect(constructMetadata).toEqual({
     version: '1.0.0',
     resources: {
@@ -392,7 +392,7 @@ test('construct metadata is recoreded when requested by env variable', () => {
 
     app.synth();
 
-    const constructMetadata = JSON.parse(fs.readFileSync(path.join(app.outdir, 'construct-metadata.json'), { encoding: 'utf-8' }));
+    const constructMetadata = JSON.parse(fs.readFileSync(path.join(app.outdir, 'validation/construct-metadata.json'), { encoding: 'utf-8' }));
     expect(constructMetadata).toEqual({
       version: '1.0.0',
       resources: {
@@ -419,7 +419,7 @@ test('construct metadata is not recorded when not requested', () => {
 
   app.synth();
 
-  expect(fs.existsSync(path.join(app.outdir, 'construct-metadata.json'))).toBeFalsy();
+  expect(fs.existsSync(path.join(app.outdir, 'validation/construct-metadata.json'))).toBeFalsy();
 
 });
 


### PR DESCRIPTION
Fixes [#1039](https://github.com/cdk8s-team/cdk8s/issues/1039)

When users try to deploy their manifests on the `dist/` directory like so:
```
kubectl apply -f dist/
```
They get an error if a `construct-metadata.json` file is generated -- this is because `kubectl` attempts to apply on the construct metadata file as well, even though it is only used for validation purposes and not as a kubernetes manifest:
```
error: unable to decode "dist\\construct-metadata.json": Object 'Kind' is missing in '{"version":"1.0.0","resources":{"helm-bitnami-java-bitnami-c8b78b77-redis":{"path":"helm-bitnami-java/bitnami/helm-bitnami-java-bitnami-c8b78b77-redis-service-default"},"helm-bitnami-java-bitnami-c8b78b77-redis-configuration":{"path":"helm-bitnami-java/bitnami/helm-bitnami-java-bitnami-c8b78b77-redis-configuration-configmap-default"},"helm-bitnami-java-bitnami-c8b78b77-redis-health":{"path":"helm-bitnami-java/bitnami/helm-bitnami-java-bitnami-c8b78b77-redis-health-configmap-default"},"helm-bitnami-java-bitnami-c8b78b77-redis-scripts":{"path":"helm-bitnami-java/bitnami/helm-bitnami-java-bitnami-c8b78b77-redis-scripts-configmap-default"},"helm-bitnami-java-bitnami-c8b78b77-redis-headless":{"path":"helm-bitnami-java/bitnami/helm-bitnami-java-bitnami-c8b78b77-redis-headless-service-default"},"helm-bitnami-java-bitnami-c8b78b77-redis-node"
```


To fix this, a `validations/` subdirectory has been added in the `dist/` directory. Now the construct metadata file will be found at `dist/validations/construct-metadata.json`. `kubectl apply` only works on files directly in a folder and does not recursively apply on subdirectories unless the `--recursive` flag is used.

The Chart tests were updated with this new filepath.