### PR TITLE
chore: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/test/__snapshots__/yaml.test.ts.snap
+++ b/test/__snapshots__/yaml.test.ts.snap
@@ -87,7 +87,7 @@ Array [
         "spec": Object {
           "containers": Array [
             Object {
-              "image": "k8s.gcr.io/redis:e2e",
+              "image": "registry.k8s.io/redis:e2e",
               "name": "master",
               "ports": Array [
                 Object {

--- a/test/fixtures/guestbook-all-in-one.yaml
+++ b/test/fixtures/guestbook-all-in-one.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: k8s.gcr.io/redis:e2e  # or just image: redis
+        image: registry.k8s.io/redis:e2e  # or just image: redis
         resources:
           requests:
             cpu: 100m
@@ -104,7 +104,7 @@ metadata:
     tier: frontend
 spec:
   # comment or delete the following line if you want to use a LoadBalancer
-  type: NodePort 
+  type: NodePort
   # if your cluster supports it, uncomment the following to automatically create
   # an external load-balanced IP for the frontend service.
   # type: LoadBalancer


### PR DESCRIPTION
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.