### PR TITLE
chore: bump yaml version for security finding (#1193)

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -113,7 +113,6 @@
     },
     {
       "name": "yaml",
-      "version": "2.0.0-7",
       "type": "bundled"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -427,25 +427,25 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='jsii,yaml'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='jsii'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='jsii,yaml'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='jsii'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='jsii,yaml'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='jsii'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='jsii,yaml'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='jsii'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='jsii,yaml'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='jsii'"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @cdk8s/projen-common @types/follow-redirects @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser constructs eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii json-schema-to-typescript npm-check-updates projen standard-version ts-jest typescript fast-json-patch follow-redirects constructs"
+          "exec": "yarn upgrade"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -10,7 +10,7 @@ const project = new Cdk8sTeamJsiiProject({
     'constructs',
   ],
   bundledDeps: [
-    'yaml@2.0.0-7',
+    'yaml',
     'follow-redirects',
     'fast-json-patch',
   ],
@@ -40,9 +40,6 @@ const project = new Cdk8sTeamJsiiProject({
     },
   },
   golangBranch: '1.x',
-  depsUpgradeOptions: {
-    exclude: ['yaml'],
-  },
 });
 
 // _loadurl.js is written in javascript so we need to commit it and also copy it

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "fast-json-patch": "^3.1.1",
     "follow-redirects": "^1.15.2",
-    "yaml": "2.0.0-7"
+    "yaml": "2.2.2"
   },
   "bundledDependencies": [
     "fast-json-patch",

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -9,7 +9,7 @@ const MAX_DOWNLOAD_BUFFER = 10 * 1024 * 1024;
 // Set default YAML schema to 1.1. This ensures saved YAML is backward compatible with other parsers, such as PyYAML
 // It also ensures that octal numbers in the form `0775` will be parsed
 // correctly on YAML load. (see https://github.com/eemeli/yaml/issues/205)
-YAML.defaultOptions.version = '1.1';
+const yamlSchemaVersion = '1.1';
 
 /**
  * YAML utilities.
@@ -72,7 +72,9 @@ export class Yaml {
   public static load(urlOrFile: string): any[] {
     const body = loadurl(urlOrFile);
 
-    const objects = YAML.parseAllDocuments(body);
+    const objects = YAML.parseAllDocuments(body, {
+      version: yamlSchemaVersion,
+    });
     const result = new Array<any>();
 
     for (const obj of objects.map(x => x.toJSON())) {

--- a/test/__snapshots__/yaml.test.ts.snap
+++ b/test/__snapshots__/yaml.test.ts.snap
@@ -307,7 +307,7 @@ hello:
 `;
 
 exports[`save strings are quoted 1`] = `
-"foo: \\"on\\"
+"foo: on
 bar: this has a \\"big quote\\"
 not_a_string: true
 "

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -44,7 +44,9 @@ test('can hook into chart synthesis with during synthYaml', () => {
   }
 
   new MyChart(app, 'Chart');
-  const manifest = YAML.parseAllDocuments(app.synthYaml());
+  const manifest = YAML.parseAllDocuments(app.synthYaml(), {
+    version: '1.1',
+  });
   expect(manifest.length).toEqual(1);
   expect(manifest[0].get('kind')).toEqual('Kind2');
 

--- a/test/include.test.ts
+++ b/test/include.test.ts
@@ -12,7 +12,9 @@ test('Include can be used to load from YAML', () => {
   new Include(chart, 'guestbook', { url: source });
 
   // THEN
-  const expected = yaml.parseAllDocuments(fs.readFileSync(source, 'utf-8')).map(x => x.toJSON());
+  const expected = yaml.parseAllDocuments(fs.readFileSync(source, 'utf-8'), {
+    version: '1.1',
+  }).map(x => x.toJSON());
   const actual = Testing.synth(chart);
   expect(actual).toStrictEqual(expected);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6740,12 +6740,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@2.0.0-7:
-  version "2.0.0-7"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-7.tgz#9799d9d85dfc8f01e4cc425e18e09215364beef1"
-  integrity sha512-RbI2Tm3hl9AoHY4wWyWvGvJfFIbHOzuzaxum6ez1A0vve+uXgNor03Wys4t+2sgjJSVSe+B2xerd1/dnvqHlOA==
-
-yaml@^2.2.2:
+yaml@2.2.2, yaml@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
   integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==


### PR DESCRIPTION
# Backport

This will backport the following commits from `2.x` to `1.x`:
 - [chore: bump yaml version for security finding (#1193)](https://github.com/cdk8s-team/cdk8s-core/pull/1193)

<!--- Backport version: 8.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)