### PR TITLE
fix: `synth` produces a backwards incompatible YAML 1.2 format

### DIFF
--- a/src/helm.ts
+++ b/src/helm.ts
@@ -2,10 +2,10 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { Construct } from 'constructs';
-import * as yaml from 'yaml';
 import { _child_process } from './_child_process';
 import { Include } from './include';
 import { Names } from './names';
+import { Yaml } from './yaml';
 
 const MAX_HELM_BUFFER = 10 * 1024 * 1024;
 
@@ -96,7 +96,7 @@ export class Helm extends Include {
     // values
     if (props.values && Object.keys(props.values).length > 0) {
       const valuesPath = path.join(workdir, 'overrides.yaml');
-      fs.writeFileSync(valuesPath, yaml.stringify(props.values));
+      fs.writeFileSync(valuesPath, Yaml.stringify(props.values));
       args.push('-f', valuesPath);
     }
 

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -43,7 +43,7 @@ export class Yaml {
    */
   public static stringify(...docs: any[]) {
     return docs.map(
-      r => r === undefined ? '\n' : YAML.stringify(r, { keepUndefined: true, lineWidth: 0 }),
+      r => r === undefined ? '\n' : YAML.stringify(r, { keepUndefined: true, lineWidth: 0, version: yamlSchemaVersion }),
     ).join('---\n');
   }
 

--- a/test/__snapshots__/yaml.test.ts.snap
+++ b/test/__snapshots__/yaml.test.ts.snap
@@ -307,7 +307,7 @@ hello:
 `;
 
 exports[`save strings are quoted 1`] = `
-"foo: on
+"foo: \\"on\\"
 bar: this has a \\"big quote\\"
 not_a_string: true
 "

--- a/test/yaml.test.ts
+++ b/test/yaml.test.ts
@@ -120,3 +120,14 @@ test('stringify() accepts multiple documents', () => {
     '',
   ].join('\n'));
 });
+
+test("strings don't become booleans", () => {
+  const actual = Yaml.stringify({ a_yes: 'yes', a_no: 'no', a_true: 'true', a_false: 'false' });
+  expect(actual).toStrictEqual([
+    'a_yes: "yes"',
+    'a_no: "no"',
+    'a_true: "true"',
+    'a_false: "false"',
+    '',
+  ].join('\n'));
+});


### PR DESCRIPTION
We forgot a couple of places when bumping the `yaml` version in this [PR](https://github.com/cdk8s-team/cdk8s-core/pull/1193).

Fixes https://github.com/cdk8s-team/cdk8s-core/issues/1230