### PR TITLE
fix(metadata): `List*` generated resources fail to compile

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -735,7 +735,6 @@ Metadata associated with this object.
 import org.cdk8s.ApiObjectMetadata;
 
 ApiObjectMetadata.builder()
-//  .additionalAttributes(java.util.Map<java.lang.String, java.lang.Object>)
 //  .annotations(java.util.Map<java.lang.String, java.lang.String>)
 //  .finalizers(java.util.List<java.lang.String>)
 //  .labels(java.util.Map<java.lang.String, java.lang.String>)
@@ -744,18 +743,6 @@ ApiObjectMetadata.builder()
 //  .ownerReferences(java.util.List<OwnerReference>)
     .build();
 ```
-
-##### `additionalAttributes`<sup>Optional</sup> <a name="org.cdk8s.ApiObjectMetadata.property.additionalAttributes"></a>
-
-```java
-public java.util.Map<java.lang.String, java.lang.Object> getAdditionalAttributes();
-```
-
-- *Type:* java.util.Map<java.lang.String, `java.lang.Object`>
-
-Additional metadata attributes.
-
----
 
 ##### `annotations`<sup>Optional</sup> <a name="org.cdk8s.ApiObjectMetadata.property.annotations"></a>
 
@@ -901,7 +888,6 @@ Options for `ApiObjectMetadataDefinition`.
 import org.cdk8s.ApiObjectMetadataDefinitionOptions;
 
 ApiObjectMetadataDefinitionOptions.builder()
-//  .additionalAttributes(java.util.Map<java.lang.String, java.lang.Object>)
 //  .annotations(java.util.Map<java.lang.String, java.lang.String>)
 //  .finalizers(java.util.List<java.lang.String>)
 //  .labels(java.util.Map<java.lang.String, java.lang.String>)
@@ -911,18 +897,6 @@ ApiObjectMetadataDefinitionOptions.builder()
     .apiObject(ApiObject)
     .build();
 ```
-
-##### `additionalAttributes`<sup>Optional</sup> <a name="org.cdk8s.ApiObjectMetadataDefinitionOptions.property.additionalAttributes"></a>
-
-```java
-public java.util.Map<java.lang.String, java.lang.Object> getAdditionalAttributes();
-```
-
-- *Type:* java.util.Map<java.lang.String, `java.lang.Object`>
-
-Additional metadata attributes.
-
----
 
 ##### `annotations`<sup>Optional</sup> <a name="org.cdk8s.ApiObjectMetadataDefinitionOptions.property.annotations"></a>
 
@@ -1797,7 +1771,6 @@ Object metadata.
 import org.cdk8s.ApiObjectMetadataDefinition;
 
 ApiObjectMetadataDefinition.Builder.create()
-//  .additionalAttributes(java.util.Map<java.lang.String, java.lang.Object>)
 //  .annotations(java.util.Map<java.lang.String, java.lang.String>)
 //  .finalizers(java.util.List<java.lang.String>)
 //  .labels(java.util.Map<java.lang.String, java.lang.String>)
@@ -1807,14 +1780,6 @@ ApiObjectMetadataDefinition.Builder.create()
     .apiObject(ApiObject)
     .build();
 ```
-
-##### `additionalAttributes`<sup>Optional</sup> <a name="org.cdk8s.ApiObjectMetadataDefinitionOptions.parameter.additionalAttributes"></a>
-
-- *Type:* java.util.Map<java.lang.String, `java.lang.Object`>
-
-Additional metadata attributes.
-
----
 
 ##### `annotations`<sup>Optional</sup> <a name="org.cdk8s.ApiObjectMetadataDefinitionOptions.parameter.annotations"></a>
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -761,7 +761,6 @@ Metadata associated with this object.
 import cdk8s
 
 cdk8s.ApiObjectMetadata(
-  additional_attributes: typing.Mapping[typing.Any] = None,
   annotations: typing.Mapping[str] = None,
   finalizers: typing.List[str] = None,
   labels: typing.Mapping[str] = None,
@@ -770,18 +769,6 @@ cdk8s.ApiObjectMetadata(
   owner_references: typing.List[OwnerReference] = None
 )
 ```
-
-##### `additional_attributes`<sup>Optional</sup> <a name="cdk8s.ApiObjectMetadata.property.additional_attributes"></a>
-
-```python
-additional_attributes: typing.Mapping[typing.Any]
-```
-
-- *Type:* typing.Mapping[`typing.Any`]
-
-Additional metadata attributes.
-
----
 
 ##### `annotations`<sup>Optional</sup> <a name="cdk8s.ApiObjectMetadata.property.annotations"></a>
 
@@ -927,7 +914,6 @@ Options for `ApiObjectMetadataDefinition`.
 import cdk8s
 
 cdk8s.ApiObjectMetadataDefinitionOptions(
-  additional_attributes: typing.Mapping[typing.Any] = None,
   annotations: typing.Mapping[str] = None,
   finalizers: typing.List[str] = None,
   labels: typing.Mapping[str] = None,
@@ -937,18 +923,6 @@ cdk8s.ApiObjectMetadataDefinitionOptions(
   api_object: ApiObject
 )
 ```
-
-##### `additional_attributes`<sup>Optional</sup> <a name="cdk8s.ApiObjectMetadataDefinitionOptions.property.additional_attributes"></a>
-
-```python
-additional_attributes: typing.Mapping[typing.Any]
-```
-
-- *Type:* typing.Mapping[`typing.Any`]
-
-Additional metadata attributes.
-
----
 
 ##### `annotations`<sup>Optional</sup> <a name="cdk8s.ApiObjectMetadataDefinitionOptions.property.annotations"></a>
 
@@ -1823,7 +1797,6 @@ Object metadata.
 import cdk8s
 
 cdk8s.ApiObjectMetadataDefinition(
-  additional_attributes: typing.Mapping[typing.Any] = None,
   annotations: typing.Mapping[str] = None,
   finalizers: typing.List[str] = None,
   labels: typing.Mapping[str] = None,
@@ -1833,14 +1806,6 @@ cdk8s.ApiObjectMetadataDefinition(
   api_object: ApiObject
 )
 ```
-
-##### `additional_attributes`<sup>Optional</sup> <a name="cdk8s.ApiObjectMetadataDefinitionOptions.parameter.additional_attributes"></a>
-
-- *Type:* typing.Mapping[`typing.Any`]
-
-Additional metadata attributes.
-
----
 
 ##### `annotations`<sup>Optional</sup> <a name="cdk8s.ApiObjectMetadataDefinitionOptions.parameter.annotations"></a>
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -542,18 +542,6 @@ import { ApiObjectMetadata } from 'cdk8s'
 const apiObjectMetadata: ApiObjectMetadata = { ... }
 ```
 
-##### `additionalAttributes`<sup>Optional</sup> <a name="cdk8s.ApiObjectMetadata.property.additionalAttributes"></a>
-
-```typescript
-public readonly additionalAttributes: {[ key: string ]: any};
-```
-
-- *Type:* {[ key: string ]: `any`}
-
-Additional metadata attributes.
-
----
-
 ##### `annotations`<sup>Optional</sup> <a name="cdk8s.ApiObjectMetadata.property.annotations"></a>
 
 ```typescript
@@ -699,18 +687,6 @@ import { ApiObjectMetadataDefinitionOptions } from 'cdk8s'
 
 const apiObjectMetadataDefinitionOptions: ApiObjectMetadataDefinitionOptions = { ... }
 ```
-
-##### `additionalAttributes`<sup>Optional</sup> <a name="cdk8s.ApiObjectMetadataDefinitionOptions.property.additionalAttributes"></a>
-
-```typescript
-public readonly additionalAttributes: {[ key: string ]: any};
-```
-
-- *Type:* {[ key: string ]: `any`}
-
-Additional metadata attributes.
-
----
 
 ##### `annotations`<sup>Optional</sup> <a name="cdk8s.ApiObjectMetadataDefinitionOptions.property.annotations"></a>
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -97,8 +97,10 @@ export interface ApiObjectMetadata {
 
   /**
    * Additional metadata attributes.
+   * @jsii ignore
+   * @see https://github.com/cdk8s-team/cdk8s-core/issues/1297
    */
-  readonly additionalAttributes?: { [key: string]: any };
+  readonly [key: string]: any;
 }
 
 /**
@@ -170,7 +172,10 @@ export class ApiObjectMetadataDefinition {
     this.finalizers = options.finalizers ? [...options.finalizers] : [];
     this.ownerReferences = options.ownerReferences ? [...options.ownerReferences] : [];
     this.apiObject = options.apiObject;
-    this._additionalAttributes = options.additionalAttributes ?? { };
+    this._additionalAttributes = options ?? { };
+
+    // otherwise apiObject is passed to the resolving logic, which expectadly fails
+    delete this._additionalAttributes.apiObject;
   }
 
   /**

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -172,7 +172,7 @@ export class ApiObjectMetadataDefinition {
     this.finalizers = options.finalizers ? [...options.finalizers] : [];
     this.ownerReferences = options.ownerReferences ? [...options.ownerReferences] : [];
     this.apiObject = options.apiObject;
-    this._additionalAttributes = options ?? { };
+    this._additionalAttributes = options;
 
     // otherwise apiObject is passed to the resolving logic, which expectadly fails
     delete this._additionalAttributes.apiObject;

--- a/test/api-object.test.ts
+++ b/test/api-object.test.ts
@@ -36,11 +36,9 @@ test('printed yaml is alphabetical', () => {
       firstProperty: 'hello',
     },
     metadata: {
-      additionalAttributes: {
-        meta: {
-          zzz: 'hello',
-          aaa: 123,
-        },
+      meta: {
+        zzz: 'hello',
+        aaa: 123,
       },
     },
     apiVersion: 'v1',
@@ -443,9 +441,7 @@ test('custom resolver', () => {
     kind: 'Service',
     apiVersion: 'v1',
     metadata: {
-      additionalAttributes: {
-        foo: 'bar',
-      },
+      foo: 'bar',
     },
     spec: {
       type: 'LoadBalancer',
@@ -496,9 +492,7 @@ test('multiple custom resolvers', () => {
     kind: 'Service',
     apiVersion: 'v1',
     metadata: {
-      additionalAttributes: {
-        foo: 'bar',
-      },
+      foo: 'bar',
     },
     spec: {
       type: 'LoadBalancer',
@@ -545,9 +539,7 @@ test('annonymous object custom resolver', () => {
     kind: 'Service',
     apiVersion: 'v1',
     metadata: {
-      additionalAttributes: {
-        foo: 'bar',
-      },
+      foo: 'bar',
     },
     spec: {
       type: resolvable,

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -125,11 +125,9 @@ test('ensure Lazy properties are resolved', () => {
 test('Can include arbirary key/value options', () => {
   const meta = new ApiObjectMetadataDefinition({
     apiObject: createApiObject(),
-    additionalAttributes: {
-      foo: 123,
-      bar: {
-        helloL: 'world',
-      },
+    foo: 123,
+    bar: {
+      helloL: 'world',
     },
   });
 


### PR DESCRIPTION
Observed when the [CLI upgraded](https://github.com/cdk8s-team/cdk8s-cli/actions/runs/6373225617/job/17296762915?pr=1459) the `cdk8s` dependency.

```console
|      ~~~~~
  | k8s.ts:5192:22 - error TS2345: Argument of type '{ metadata?: ListMeta | undefined; items: KubeClusterRoleBindingProps[]; apiVersion: string; kind: string; }' is not assignable to parameter of type 'ApiObjectProps'.
  |   Types of property 'metadata' are incompatible.
  |     Type 'ListMeta | undefined' is not assignable to type 'ApiObjectMetadata | undefined'.
  | 5192     super(scope, id, {
  |                           ~
  | 5193       ...KubeClusterRoleBindingList.GVK,
  |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  | 5194       ...props,
  |      ~~~~~~~~~~~~~~~
  | 5195     });
  |      ~~~~~
  | k8s.ts:5246:22 - error TS
```

This PR reverts the breaking change introduced to `ApiObjectMetadataOptions` - it was an attempt to cleanup the code, but looks like it needs to be done more carefully. 