### PR TITLE
fix(resolve): resolve constructs with child objects that reference instances of classes

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -2738,7 +2738,7 @@ Lazy.any(IAnyProducer producer)
 
 - *Implements:* [`org.cdk8s.IResolver`](#org.cdk8s.IResolver)
 
-Resolvers instanecs of `Lazy`.
+Resolves instances of `Lazy`.
 
 #### Initializers <a name="org.cdk8s.LazyResolver.Initializer"></a>
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -2942,7 +2942,7 @@ cdk8s.Lazy.any(
 
 - *Implements:* [`cdk8s.IResolver`](#cdk8s.IResolver)
 
-Resolvers instanecs of `Lazy`.
+Resolves instances of `Lazy`.
 
 #### Initializers <a name="cdk8s.LazyResolver.Initializer"></a>
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2307,7 +2307,7 @@ Lazy.any(producer: IAnyProducer)
 
 - *Implements:* [`cdk8s.IResolver`](#cdk8s.IResolver)
 
-Resolvers instanecs of `Lazy`.
+Resolves instances of `Lazy`.
 
 #### Initializers <a name="cdk8s.LazyResolver.Initializer"></a>
 

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -56,7 +56,7 @@ export interface IResolver {
 }
 
 /**
- * Resolvers instanecs of `Lazy`.
+ * Resolves instances of `Lazy`.
  */
 export class LazyResolver implements IResolver {
 
@@ -136,8 +136,8 @@ export function resolve(key: string[], value: any, apiObject: ApiObject): any {
     return value.map((x, i) => resolve([...key, `${i}`], x, apiObject));
   }
 
-  // dictionrary - resolve leafs
-  if (value.constructor == Object) {
+  // dictionary - resolve leafs
+  if (value.constructor == Object || typeof(value) === 'object') {
     const result: any = {};
     for (const [k, v] of Object.entries(value)) {
       result[k] = resolve([...key, k], v, apiObject);

--- a/test/__snapshots__/api-object.test.ts.snap
+++ b/test/__snapshots__/api-object.test.ts.snap
@@ -80,6 +80,53 @@ exports[`printed yaml is alphabetical 1`] = `
 ]"
 `;
 
+exports[`synth APIObject with class in props 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "cluster": Object {
+      "name": "test",
+    },
+    "kind": "NewObject",
+    "metadata": Object {
+      "name": "test-myobject-c81c5228",
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "ResourceType",
+    "metadata": Object {
+      "name": "test-myobject-c8b02486",
+    },
+    "spec": Object {
+      "prop2": Object {
+        "world": 123,
+      },
+    },
+  },
+]
+`;
+
+exports[`synth construct with class referenced in child object 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "ResourceType",
+    "metadata": Object {
+      "name": "test-myconstruct-c89c4ae1",
+    },
+    "spec": Object {
+      "cluster": Object {
+        "name": "test",
+      },
+      "prop2": Object {
+        "world": 123,
+      },
+    },
+  },
+]
+`;
+
 exports[`synthesized resource name is based on path 1`] = `
 Array [
   Object {


### PR DESCRIPTION
Hopefully the test cases here explain my intent more clearly, but we need to resolve where the values are instances of classes that can be parsed to strings. This behavior was working until the recent refactor. 

I believe this change is the least-obtrusive option to retain backward compatibility, as it just re-adds the gate that was originally in the resolve function. But, I'm open to any feedback or improvements you'd like to see here.