### PR TITLE
feat(api-object): improved error message when `toJson` fails

### DIFF
--- a/src/api-object.ts
+++ b/src/api-object.ts
@@ -198,26 +198,31 @@ export class ApiObject extends Construct {
    * `CDK8S_DISABLE_SORT` environment variable to any non-empty value.
    */
   public toJson(): any {
-    const data: any = {
-      ...this.props,
-      metadata: this.metadata.toJson(),
-    };
 
-    const sortKeys = process.env.CDK8S_DISABLE_SORT ? false : true;
-    const json = sanitizeValue(resolve([], data, this), { sortKeys });
-    const patched = JsonPatch.apply(json, ...this.patches);
+    try {
+      const data: any = {
+        ...this.props,
+        metadata: this.metadata.toJson(),
+      };
 
-    // reorder top-level keys so that we first have "apiVersion", "kind" and
-    // "metadata" and then all the rest
-    const result: any = {};
-    const orderedKeys = ['apiVersion', 'kind', 'metadata', ...Object.keys(patched)];
-    for (const k of orderedKeys) {
-      if (k in patched) {
-        result[k] = patched[k];
+      const sortKeys = process.env.CDK8S_DISABLE_SORT ? false : true;
+      const json = sanitizeValue(resolve([], data, this), { sortKeys });
+      const patched = JsonPatch.apply(json, ...this.patches);
+
+      // reorder top-level keys so that we first have "apiVersion", "kind" and
+      // "metadata" and then all the rest
+      const result: any = {};
+      const orderedKeys = ['apiVersion', 'kind', 'metadata', ...Object.keys(patched)];
+      for (const k of orderedKeys) {
+        if (k in patched) {
+          result[k] = patched[k];
+        }
       }
-    }
 
-    return result;
+      return result;
+    } catch (e) {
+      throw new Error(`Failed serializing construct at path '${this.node.path}' with name '${this.name}': ${e}`);
+    }
   }
 }
 

--- a/test/api-object.test.ts
+++ b/test/api-object.test.ts
@@ -7,6 +7,7 @@ import {
   JsonPatch,
   Lazy,
   ResolutionContext,
+  Size,
   Testing,
 } from '../src';
 
@@ -624,4 +625,20 @@ test('can resolve L1', () => {
       },
     }
   `);
+});
+
+test('toJson error message', () => {
+
+  const chart = Testing.chart();
+
+  const obj = new ApiObject(chart, 'ConfigMap', {
+    kind: 'ConfigMap',
+    apiVersion: 'v1',
+    data: {
+      size: Size.gibibytes(5),
+    },
+  });
+
+  expect(() => obj.toJson()).toThrowError(`Failed serializing construct at path '${obj.node.path}' with name '${obj.name}': Error: can't render non-simple object of type 'Size'`);
+
 });


### PR DESCRIPTION
Include the construct path and name in addition to the underlying resolution error.

This was brought up and discussed in our [slack channel](https://cdk-dev.slack.com/archives/C0184GCBY4X/p1697635140466729).