### PR TITLE
chore: backport implement `apiObjects` function (#1795) to 1.x

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -512,6 +512,18 @@ a construct node.
 
 #### Properties <a name="Properties"></a>
 
+##### `apiObjects`<sup>Required</sup> <a name="org.cdk8s.Chart.property.apiObjects"></a>
+
+```java
+public java.util.List<ApiObject> getApiObjects();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.ApiObject`](#org.cdk8s.ApiObject)>
+
+Returns all the included API objects.
+
+---
+
 ##### `labels`<sup>Required</sup> <a name="org.cdk8s.Chart.property.labels"></a>
 
 ```java

--- a/docs/python.md
+++ b/docs/python.md
@@ -534,6 +534,18 @@ a construct node.
 
 #### Properties <a name="Properties"></a>
 
+##### `api_objects`<sup>Required</sup> <a name="cdk8s.Chart.property.api_objects"></a>
+
+```python
+api_objects: typing.List[ApiObject]
+```
+
+- *Type:* typing.List[[`cdk8s.ApiObject`](#cdk8s.ApiObject)]
+
+Returns all the included API objects.
+
+---
+
 ##### `labels`<sup>Required</sup> <a name="cdk8s.Chart.property.labels"></a>
 
 ```python

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -402,6 +402,18 @@ a construct node.
 
 #### Properties <a name="Properties"></a>
 
+##### `apiObjects`<sup>Required</sup> <a name="cdk8s.Chart.property.apiObjects"></a>
+
+```typescript
+public readonly apiObjects: ApiObject[];
+```
+
+- *Type:* [`cdk8s.ApiObject`](#cdk8s.ApiObject)[]
+
+Returns all the included API objects.
+
+---
+
 ##### `labels`<sup>Required</sup> <a name="cdk8s.Chart.property.labels"></a>
 
 ```typescript

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -147,5 +147,11 @@ export class Chart extends Construct {
   public toJson(): any[] {
     return App._synthChart(this);
   }
-}
 
+  /**
+   * Returns all the included API objects.
+   */
+  get apiObjects(): ApiObject[] {
+    return this.node.children.filter((o): o is ApiObject => o instanceof ApiObject);
+  }
+}

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -152,6 +152,6 @@ export class Chart extends Construct {
    * Returns all the included API objects.
    */
   get apiObjects(): ApiObject[] {
-    return this.node.children.filter((o): o is ApiObject => o instanceof ApiObject);
+    return Node.of(this).children.filter((o): o is ApiObject => o instanceof ApiObject);
   }
 }

--- a/src/include.ts
+++ b/src/include.ts
@@ -38,6 +38,6 @@ export class Include extends Construct {
    * Returns all the included API objects.
    */
   public get apiObjects(): ApiObject[] {
-    return Node.of(this).children.filter(o => o instanceof ApiObject) as ApiObject[];
+    return Node.of(this).children.filter((o): o is ApiObject => o instanceof ApiObject);
   }
 }

--- a/test/chart.test.ts
+++ b/test/chart.test.ts
@@ -457,3 +457,30 @@ class CustomNestedConstruct extends Construct {
     this.obj = new CustomConstruct(this, 'nested');
   }
 }
+
+test('apiObjects returns all the API objects', () => {
+  // GIVEN
+  const chart = Testing.chart();
+
+  // WHEN
+
+  new ApiObject(chart, 'obj1', {
+    kind: 'Deployment',
+    apiVersion: 'v1',
+  });
+  new ApiObject(chart, 'obj2', {
+    apiVersion: 'v1',
+    kind: 'Foo',
+    metadata: {
+      name: 'resource1',
+    },
+  });
+  new ApiObject(chart, 'obj3', {
+    apiVersion: 'v1',
+    kind: 'Bar',
+    metadata: {
+      name: 'resource1',
+    },
+  });
+  expect(chart.apiObjects.map((x) => x.kind).sort()).toEqual(['Bar', 'Deployment', 'Foo']);
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `2.x` to `1.x`:
 - [feat(chart): implement &#x60;apiObjects&#x60; function (#1795)](https://github.com/cdk8s-team/cdk8s-core/pull/1795)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)