### PR TITLE
fix(app): include namespace in resource file names to prevent collisions

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -224,8 +224,7 @@ export class App extends Construct {
 
           apiObjects.forEach((apiObject) => {
             if (!(apiObject === undefined)) {
-              const fileName = `${`${apiObject.kind}.${apiObject.metadata.name}`
-                .replace(/[^0-9a-zA-Z-_.]/g, '')}`;
+              const fileName = sanitizeResourceFileName(apiObject.kind, apiObject.metadata.name, apiObject.metadata.namespace);
               Yaml.save(path.join(this.outdir, fileName + this.outputFileExtension), [apiObject]);
             }
           });
@@ -242,9 +241,9 @@ export class App extends Construct {
 
           apiObjects.forEach((apiObject) => {
             if (!(apiObject === undefined)) {
-              const fileName = `${`${apiObject.kind}.${apiObject.metadata.name}`
-                .replace(/[^0-9a-zA-Z-_.]/g, '')}`;
-              Yaml.save(path.join(fullOutDir, fileName + this.outputFileExtension), [apiObject.toJson()]);
+              const json = apiObject.toJson();
+              const fileName = sanitizeResourceFileName(json.kind, json.metadata.name, json.metadata.namespace);
+              Yaml.save(path.join(fullOutDir, fileName + this.outputFileExtension), [json]);
             }
           });
         }
@@ -400,6 +399,11 @@ class IndexedChartNamer extends SimpleChartNamer implements ChartNamer {
     this.index++;
     return name;
   }
+}
+
+function sanitizeResourceFileName(kind: string, name: string, namespace?: string): string {
+  const parts = namespace ? `${kind}.${namespace}.${name}` : `${kind}.${name}`;
+  return parts.replace(/[^0-9a-zA-Z-_.]/g, '');
 }
 
 class SimpleChartFolderNamer implements ChartNamer {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -536,6 +536,62 @@ test('Modified file extensions with varying output types; two charts, no objects
 });
 
 
+test('FILE_PER_RESOURCE and FOLDER_PER_CHART_FILE_PER_RESOURCE include namespace in filename to avoid collisions', () => {
+  const testSpecs = [
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_RESOURCE },
+      result: [
+        'ConfigMap.dev.my-config.k8s.yaml',
+        'ConfigMap.prod.my-config.k8s.yaml',
+      ],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FOLDER_PER_CHART_FILE_PER_RESOURCE },
+      result: [
+        'chart1/ConfigMap.dev.my-config.k8s.yaml',
+        'chart1/ConfigMap.prod.my-config.k8s.yaml',
+      ],
+    },
+  ];
+
+  for (const testSpec of testSpecs) {
+    const app = Testing.app(testSpec.props);
+    const chart = new Chart(app, 'chart1');
+
+    new ApiObject(chart, 'obj1', {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: 'my-config', namespace: 'dev' },
+    });
+    new ApiObject(chart, 'obj2', {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: 'my-config', namespace: 'prod' },
+    });
+
+    app.synth();
+
+    expect(getFilesAndFolders(app.outdir).sort()).toEqual(testSpec.result);
+  }
+});
+
+test('FILE_PER_RESOURCE without namespace preserves original filename format', () => {
+  const app = Testing.app({ yamlOutputType: YamlOutputType.FILE_PER_RESOURCE });
+  const chart = new Chart(app, 'chart1');
+
+  new ApiObject(chart, 'obj1', {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: { name: 'my-config' },
+  });
+
+  app.synth();
+
+  expect(getFilesAndFolders(app.outdir)).toEqual([
+    'ConfigMap.my-config.k8s.yaml',
+  ]);
+});
+
 /**
  * Get the list of files and folders in the source folder and sub folders (one level deep)
  * @param sourceDir Folder in which to search for files and folders


### PR DESCRIPTION
Fixes https://github.com/cdk8s-team/cdk8s/issues/2821

## Summary

When using `FILE_PER_RESOURCE` or `FOLDER_PER_CHART_FILE_PER_RESOURCE` output types, resources with the same kind and name but different namespaces generate identical file names. This causes later resources to silently overwrite earlier ones, resulting in data loss.

For example, two `ConfigMap` resources named `my-config` in namespaces `dev` and `prod` within the same chart both get the file name `ConfigMap.my-config.k8s.yaml`, and only the last one survives.

## Changes

- **`src/app.ts`**: Introduced a `sanitizeResourceFileName` helper that includes the namespace in the file name when present (e.g., `ConfigMap.prod.my-config.k8s.yaml`). Resources without a namespace keep the original format (`ConfigMap.my-config.k8s.yaml`), preserving backward compatibility.
- **`test/app.test.ts`**: Added two test cases:
  - Verifies that same-kind-and-name resources with different namespaces produce distinct file names in both `FILE_PER_RESOURCE` and `FOLDER_PER_CHART_FILE_PER_RESOURCE` modes
  - Verifies that resources without a namespace retain the original file name format

## Test plan

- [x] All 185 existing tests pass
- [x] New test cases validate the fix and backward compatibility
- [x] `npx projen compile` succeeds